### PR TITLE
ULITP-4711: Delay in Cleanse Report link generation.

### DIFF
--- a/src/KeeperData.Bridge/Controllers/HoldingsController.cs
+++ b/src/KeeperData.Bridge/Controllers/HoldingsController.cs
@@ -1,0 +1,196 @@
+using KeeperData.Core.Querying.Models;
+using KeeperData.Core.Reports;
+using KeeperData.Core.Reports.Domain;
+using KeeperData.Core.Reports.SamCtsHoldings.Query.Domain;
+using Microsoft.AspNetCore.Mvc;
+using System.Diagnostics.CodeAnalysis;
+
+namespace KeeperData.Bridge.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[ExcludeFromCodeCoverage(Justification = "API controller - covered by component/integration tests.")]
+public class HoldingsController(
+    ICleanseFacade cleanseFacade,
+    ILogger<HoldingsController> logger) : ControllerBase
+{
+    /// <summary>
+    /// Gets a CTS CPH holding by its LID full identifier (format: XX-CC/PPP/HHHH).
+    /// </summary>
+    /// <param name="lidFullIdentifier">The LID full identifier (e.g., "AB-12/345/6789")</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The CTS CPH holding details, or 404 if not found</returns>
+    [HttpGet("cts/{lidFullIdentifier}")]
+    [ProducesResponseType(typeof(CtsCphHoldingResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status499ClientClosedRequest)]
+    public async Task<IActionResult> GetCtsCphHolding(string lidFullIdentifier, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Received request to get CTS CPH holding for lidFullIdentifier={LidFullIdentifier}", lidFullIdentifier);
+
+        var parsed = LidFullIdentifier.TryParse(lidFullIdentifier);
+        if (parsed is null)
+        {
+            logger.LogWarning("Invalid LID full identifier format: {LidFullIdentifier}", lidFullIdentifier);
+            return BadRequest(new ErrorResponse
+            {
+                Message = $"Invalid LID full identifier '{lidFullIdentifier}'. Expected format: XX-CC/PPP/HHHH",
+                Timestamp = DateTime.UtcNow
+            });
+        }
+
+        var holding = await cleanseFacade.Queries.CtsSamQueryService.GetCtsCphHoldingAsync(parsed, cancellationToken);
+
+        if (holding is null)
+        {
+            logger.LogWarning("CTS CPH holding not found for lidFullIdentifier={LidFullIdentifier}", lidFullIdentifier);
+            return NotFound(new ErrorResponse
+            {
+                Message = $"CTS CPH holding not found for LID full identifier: {lidFullIdentifier}",
+                Timestamp = DateTime.UtcNow
+            });
+        }
+
+        logger.LogInformation("Successfully retrieved CTS CPH holding for lidFullIdentifier={LidFullIdentifier}", lidFullIdentifier);
+
+        return Ok(new CtsCphHoldingResponse
+        {
+            LidFullIdentifier = holding.Id.Value,
+            LocationName = holding.LocationName,
+            Holding = holding.Holding,
+            Keepers = holding.Keepers,
+            Timestamp = DateTime.UtcNow
+        });
+    }
+
+    /// <summary>
+    /// Gets a SAM CPH holding by its CPH value (format: CC/PPP/HHHH).
+    /// </summary>
+    /// <param name="cph">The CPH value (e.g., "12/345/6789")</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The SAM CPH holding details, or 404 if not found</returns>
+    [HttpGet("sam/{cph}")]
+    [ProducesResponseType(typeof(SamCphHoldingResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status499ClientClosedRequest)]
+    public async Task<IActionResult> GetSamCphHolding(string cph, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Received request to get SAM CPH holding for cph={Cph}", cph);
+
+        var parsed = Cph.TryParse(cph);
+        if (parsed is null)
+        {
+            logger.LogWarning("Invalid CPH format: {Cph}", cph);
+            return BadRequest(new ErrorResponse
+            {
+                Message = $"Invalid CPH '{cph}'. Expected format: CC/PPP/HHHH",
+                Timestamp = DateTime.UtcNow
+            });
+        }
+
+        var holding = await cleanseFacade.Queries.CtsSamQueryService.GetSamCphHoldingAsync(parsed, cancellationToken);
+
+        if (holding is null)
+        {
+            logger.LogWarning("SAM CPH holding not found for cph={Cph}", cph);
+            return NotFound(new ErrorResponse
+            {
+                Message = $"SAM CPH holding not found for CPH: {cph}",
+                Timestamp = DateTime.UtcNow
+            });
+        }
+
+        logger.LogInformation("Successfully retrieved SAM CPH holding for cph={Cph}", cph);
+
+        return Ok(new SamCphHoldingResponse
+        {
+            Cph = holding.Cph.Value,
+            LocationName = holding.LocationName,
+            Holding = holding.Holding,
+            Herd = holding.Herd,
+            Parties = holding.Parties,
+            Holders = holding.Holders,
+            Timestamp = DateTime.UtcNow
+        });
+    }
+}
+
+#region Response DTOs
+
+/// <summary>
+/// Response containing CTS CPH holding details.
+/// </summary>
+[ExcludeFromCodeCoverage(Justification = "DTO record - no logic to test.")]
+public record CtsCphHoldingResponse
+{
+    /// <summary>
+    /// Gets the LID full identifier.
+    /// </summary>
+    public required string LidFullIdentifier { get; init; }
+
+    /// <summary>
+    /// Gets the location name (ADR_NAME in CTS).
+    /// </summary>
+    public string? LocationName { get; init; }
+
+    /// <summary>
+    /// Gets the holding data.
+    /// </summary>
+    public required Dictionary<string, object?> Holding { get; init; }
+
+    /// <summary>
+    /// Gets the keepers associated with the holding.
+    /// </summary>
+    public required QueryResult Keepers { get; init; }
+
+    /// <summary>
+    /// Gets the UTC timestamp of the response.
+    /// </summary>
+    public DateTime Timestamp { get; init; }
+}
+
+/// <summary>
+/// Response containing SAM CPH holding details.
+/// </summary>
+[ExcludeFromCodeCoverage(Justification = "DTO record - no logic to test.")]
+public record SamCphHoldingResponse
+{
+    /// <summary>
+    /// Gets the CPH value.
+    /// </summary>
+    public required string Cph { get; init; }
+
+    /// <summary>
+    /// Gets the location name (FEATURE_NAME in SAM).
+    /// </summary>
+    public string? LocationName { get; init; }
+
+    /// <summary>
+    /// Gets the holding data.
+    /// </summary>
+    public required Dictionary<string, object?> Holding { get; init; }
+
+    /// <summary>
+    /// Gets the herd data associated with the holding.
+    /// </summary>
+    public required QueryResult Herd { get; init; }
+
+    /// <summary>
+    /// Gets the party data associated with the holding.
+    /// </summary>
+    public required QueryResult Parties { get; init; }
+
+    /// <summary>
+    /// Gets the holder data associated with the holding.
+    /// </summary>
+    public required QueryResult Holders { get; init; }
+
+    /// <summary>
+    /// Gets the UTC timestamp of the response.
+    /// </summary>
+    public DateTime Timestamp { get; init; }
+}
+
+#endregion

--- a/src/KeeperData.Core.Reports/Cleanse/Analysis/Command/CleanseAnalysisCommandService.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Analysis/Command/CleanseAnalysisCommandService.cs
@@ -105,55 +105,22 @@ public class CleanseAnalysisCommandService(
         {
             var aggregateMetrics = new AnalysisMetrics();
 
-            await operationCommandService.UpdateProgressAsync(new UpdateProgressCommand(
-                operation.Id,
-                ProgressPercentage: 0,
-                StatusDescription: "Running analysis",
-                RecordsAnalyzed: aggregateMetrics.RecordsAnalyzed,
-                TotalRecords: 0,
-                IssuesFound: aggregateMetrics.IssuesFound,
-                IssuesResolved: aggregateMetrics.IssuesResolved), ct);
-
-            var metrics = await engine.ExecuteAsync(
-                operation.Id,
-                async (recordsAnalyzed, totalRecords, issuesFound, issuesResolved) =>
-                {
-                    // Poll for cancellation from the database
-                    if (await operationCommandService.IsCancellationRequestedAsync(operation.Id, ct))
-                    {
-                        throw new OperationCanceledException("Cancellation requested by user.");
-                    }
-
-                    var percentage = totalRecords > 0 ? (double)recordsAnalyzed / totalRecords * 100 : 0;
-                    await operationCommandService.UpdateProgressAsync(new UpdateProgressCommand(
-                        operation.Id,
-                        percentage,
-                        $"Analyzed {recordsAnalyzed} of {totalRecords} records",
-                        aggregateMetrics.RecordsAnalyzed + recordsAnalyzed,
-                        totalRecords,
-                        aggregateMetrics.IssuesFound + issuesFound,
-                        aggregateMetrics.IssuesResolved + issuesResolved), ct);
-                },
-                ct);
-
+            var metrics = await RunAnalysisPhaseAsync(operation, aggregateMetrics, ct);
             aggregateMetrics.RecordsAnalyzed += metrics.RecordsAnalyzed;
             aggregateMetrics.IssuesFound += metrics.IssuesFound;
 
-            // Deactivate all issues not touched by this operation
-            var deactivatedCount = await issueCommandService.DeactivateStaleIssuesAsync(
-                new DeactivateStaleIssuesCommand(operation.Id), ct);
+            var deactivatedCount = await RunDeactivationPhaseAsync(operation, ct);
             aggregateMetrics.IssuesResolved += deactivatedCount;
+
+            await RunExportPhaseAsync(operation, ct);
 
             stopwatch.Stop();
             await operationCommandService.CompleteOperationAsync(new CompleteOperationCommand(
                 operation.Id,
                 metrics.RecordsAnalyzed,
                 metrics.IssuesFound,
-                metrics.IssuesResolved,
+                aggregateMetrics.IssuesResolved,
                 stopwatch.ElapsedMilliseconds), ct);
-
-            // Export report to CSV, zip, and upload to S3
-            await cleanseReportExportCommandService.ExportReportAsync(operation.Id, ct);
         }
         catch (OperationCanceledException)
         {
@@ -177,6 +144,102 @@ public class CleanseAnalysisCommandService(
             try { await renewalTask; } catch { /* Ignore cancellation */ }
             await lockHandle.DisposeAsync();
         }
+    }
+
+    private async Task<AnalysisMetrics> RunAnalysisPhaseAsync(
+        CleanseAnalysisOperationDto operation, AnalysisMetrics aggregateMetrics, CancellationToken ct)
+    {
+        await operationCommandService.StartPhaseAsync(
+            new StartPhaseCommand(operation.Id, OperationPhase.Analysis, 0), ct);
+
+        var metrics = await engine.ExecuteAsync(
+            operation.Id,
+            async (recordsAnalyzed, totalRecords, issuesFound, issuesResolved) =>
+            {
+                if (await operationCommandService.IsCancellationRequestedAsync(operation.Id, ct))
+                {
+                    throw new OperationCanceledException("Cancellation requested by user.");
+                }
+
+                runStatsService.RecordSnapshot(operation.Id, nameof(OperationPhase.Analysis), recordsAnalyzed);
+
+                await operationCommandService.UpdatePhaseProgressAsync(new UpdatePhaseProgressCommand(
+                    operation.Id,
+                    OperationPhase.Analysis,
+                    recordsAnalyzed,
+                    totalRecords,
+                    $"Analyzed {recordsAnalyzed} of {totalRecords} records"), ct);
+
+                await operationCommandService.UpdateProgressAsync(new UpdateProgressCommand(
+                    operation.Id,
+                    0,
+                    $"Analyzed {recordsAnalyzed} of {totalRecords} records",
+                    aggregateMetrics.RecordsAnalyzed + recordsAnalyzed,
+                    totalRecords,
+                    aggregateMetrics.IssuesFound + issuesFound,
+                    aggregateMetrics.IssuesResolved + issuesResolved), ct);
+            },
+            ct);
+
+        await operationCommandService.CompletePhaseAsync(
+            new CompletePhaseCommand(operation.Id, OperationPhase.Analysis), ct);
+        logger.LogInformation("Phase completed: Analysis (operationId={OperationId}, records={Records}, issues={Issues})",
+            operation.Id, metrics.RecordsAnalyzed, metrics.IssuesFound);
+
+        return metrics;
+    }
+
+    private async Task<int> RunDeactivationPhaseAsync(CleanseAnalysisOperationDto operation, CancellationToken ct)
+    {
+        await operationCommandService.StartPhaseAsync(
+            new StartPhaseCommand(operation.Id, OperationPhase.Deactivation, 0), ct);
+
+        var deactivatedCount = await issueCommandService.DeactivateStaleIssuesAsync(
+            new DeactivateStaleIssuesCommand(operation.Id),
+            async (deactivatedSoFar, totalStale) =>
+            {
+                runStatsService.RecordSnapshot(operation.Id, nameof(OperationPhase.Deactivation), deactivatedSoFar);
+
+                await operationCommandService.UpdatePhaseProgressAsync(new UpdatePhaseProgressCommand(
+                    operation.Id,
+                    OperationPhase.Deactivation,
+                    deactivatedSoFar,
+                    totalStale,
+                    $"Deactivated {deactivatedSoFar} of {totalStale} stale issues"), ct);
+            },
+            ct);
+
+        await operationCommandService.CompletePhaseAsync(
+            new CompletePhaseCommand(operation.Id, OperationPhase.Deactivation), ct);
+        logger.LogInformation("Phase completed: Deactivation (operationId={OperationId}, deactivated={Deactivated})",
+            operation.Id, deactivatedCount);
+
+        return deactivatedCount;
+    }
+
+    private async Task RunExportPhaseAsync(CleanseAnalysisOperationDto operation, CancellationToken ct)
+    {
+        await operationCommandService.StartPhaseAsync(
+            new StartPhaseCommand(operation.Id, OperationPhase.Export, 0), ct);
+
+        await cleanseReportExportCommandService.ExportReportAsync(
+            operation.Id,
+            async (recordsProcessed, totalRecords, stepDescription) =>
+            {
+                runStatsService.RecordSnapshot(operation.Id, nameof(OperationPhase.Export), recordsProcessed);
+
+                await operationCommandService.UpdatePhaseProgressAsync(new UpdatePhaseProgressCommand(
+                    operation.Id,
+                    OperationPhase.Export,
+                    recordsProcessed,
+                    totalRecords,
+                    stepDescription), ct);
+            },
+            ct);
+
+        await operationCommandService.CompletePhaseAsync(
+            new CompletePhaseCommand(operation.Id, OperationPhase.Export), ct);
+        logger.LogInformation("Phase completed: Export (operationId={OperationId})", operation.Id);
     }
 
     private static async Task StartLockRenewalAsync(IDistributedLockHandle lockHandle, CancellationToken ct)

--- a/src/KeeperData.Core.Reports/Cleanse/Analysis/Command/Domain/OperationPhase.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Analysis/Command/Domain/OperationPhase.cs
@@ -1,0 +1,22 @@
+namespace KeeperData.Core.Reports.Cleanse.Analysis.Command.Domain;
+
+/// <summary>
+/// Represents the distinct phases of a cleanse analysis operation.
+/// </summary>
+public enum OperationPhase
+{
+    /// <summary>
+    /// Phase 1: Analyse CTS and SAM holdings to detect issues.
+    /// </summary>
+    Analysis,
+
+    /// <summary>
+    /// Phase 2: Deactivate stale issues not touched by this operation.
+    /// </summary>
+    Deactivation,
+
+    /// <summary>
+    /// Phase 3: Export report to CSV, zip, upload to S3, and send notification.
+    /// </summary>
+    Export
+}

--- a/src/KeeperData.Core.Reports/Cleanse/Export/Command/Abstract/ICleanseReportExportCommandService.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Export/Command/Abstract/ICleanseReportExportCommandService.cs
@@ -8,6 +8,12 @@ namespace KeeperData.Core.Reports.Cleanse.Export.Command.Abstract;
 /// </summary>
 public interface ICleanseReportExportCommandService
 {
-    Task ExportReportAsync(string operationId, CancellationToken ct);
+    /// <summary>
+    /// Exports the cleanse report for the given operation: streams issues to CSV, zips, uploads to S3, sends notification.
+    /// </summary>
+    /// <param name="operationId">The operation identifier.</param>
+    /// <param name="onProgress">Optional callback invoked with (recordsProcessed, totalRecords, stepDescription).</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task ExportReportAsync(string operationId, Func<int, int, string, Task>? onProgress, CancellationToken ct);
     Task<RegenerateReportUrlResult> RegenerateReportUrlAsync(string operationId, CancellationToken ct = default);
 }

--- a/src/KeeperData.Core.Reports/Cleanse/Export/Command/CleanseReportExportCommandService.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Export/Command/CleanseReportExportCommandService.cs
@@ -52,13 +52,13 @@ public class CleanseReportExportCommandService(
         RuleIds.SAM_CATTLE_RELATED_CPHs      // Rule 3
     ];
 
-    public async Task ExportReportAsync(string operationId, CancellationToken ct)
+    public async Task ExportReportAsync(string operationId, Func<int, int, string, Task>? onProgress, CancellationToken ct)
     {
         try
         {
             logger.LogInformation("Starting report export for operation {OperationId}", operationId);
 
-            var exportResult = await ExportAndUploadAsync(operationId, ct);
+            var exportResult = await ExportAndUploadAsync(operationId, onProgress, ct);
 
             if (exportResult.Success && !string.IsNullOrEmpty(exportResult.ReportUrl) && !string.IsNullOrEmpty(exportResult.ObjectKey))
             {
@@ -140,7 +140,7 @@ public class CleanseReportExportCommandService(
     }
 
     /// <inheritdoc />
-    private async Task<CleanseReportExportResult> ExportAndUploadAsync(string operationId, CancellationToken ct = default)
+    private async Task<CleanseReportExportResult> ExportAndUploadAsync(string operationId, Func<int, int, string, Task>? onProgress, CancellationToken ct = default)
     {
         var timestamp = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
         var zipFileName = $"cleanse-report_{timestamp}.zip";
@@ -154,17 +154,28 @@ public class CleanseReportExportCommandService(
                 "Starting cleanse report export for operation {OperationId}, timestamp {Timestamp}",
                 operationId, timestamp);
 
+            // Get total count for progress reporting
+            var totalRecords = (int)await issueQueries.GetActiveIssuesCountAsync(ct);
+
             // Step 1: Stream issues from MongoDB directly to CSV file
             tempCsvPath = Path.GetRandomFileName();
-            var recordCount = await StreamIssuesToCsvAsync(tempCsvPath, ct);
+            var recordCount = await StreamIssuesToCsvAsync(tempCsvPath, totalRecords, onProgress, ct);
             logger.LogInformation("Streamed {RecordCount} issues to CSV file at {TempPath}", recordCount, tempCsvPath);
 
             // Step 2: Create zip file
+            if (onProgress is not null)
+            {
+                await onProgress(totalRecords, totalRecords, "Compressing report");
+            }
             tempZipPath = Path.GetRandomFileName();
             CreateZipFile(tempCsvPath, tempZipPath, CsvFileName);
             logger.LogInformation("Created zip file at {ZipPath}", tempZipPath);
 
             // Step 3: Upload to S3 (using the cleanse reports blob service which has the correct prefix)
+            if (onProgress is not null)
+            {
+                await onProgress(totalRecords, totalRecords, "Uploading report to S3");
+            }
             var blobService = blobStorageServiceFactory.GetCleanseReportsBlobService();
             var zipContent = await File.ReadAllBytesAsync(tempZipPath, ct);
             await blobService.UploadAsync(zipFileName, zipContent, "application/zip", cancellationToken: ct);
@@ -205,7 +216,7 @@ public class CleanseReportExportCommandService(
     /// Issues are grouped by rule priority order, sorted by CPH within each group.
     /// Memory footprint is O(batch_size) instead of O(total_records).
     /// </summary>
-    private async Task<int> StreamIssuesToCsvAsync(string filePath, CancellationToken ct)
+    private async Task<int> StreamIssuesToCsvAsync(string filePath, int totalRecords, Func<int, int, string, Task>? onProgress, CancellationToken ct)
     {
         var recordCount = 0;
 
@@ -235,6 +246,12 @@ public class CleanseReportExportCommandService(
             {
                 await csv.FlushAsync();
                 logger.LogDebug("Streamed {RecordCount} records to CSV...", recordCount);
+
+                if (onProgress is not null)
+                {
+                    await onProgress(recordCount, totalRecords, $"Streaming issues to CSV: {recordCount} of {totalRecords}");
+                }
+
                 await throttler.DelayAsync(exportSettings.ThrottlingDelayMs, ct);
             }
         }

--- a/src/KeeperData.Core.Reports/Cleanse/Operations/Command/Abstract/ICleanseOperationCommandService.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Operations/Command/Abstract/ICleanseOperationCommandService.cs
@@ -57,4 +57,19 @@ public interface ICleanseOperationCommandService
     /// Checks whether cancellation has been requested for an operation.
     /// </summary>
     Task<bool> IsCancellationRequestedAsync(string operationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Marks a phase as running and records its total record count.
+    /// </summary>
+    Task StartPhaseAsync(StartPhaseCommand command, CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates the progress counters for a specific phase.
+    /// </summary>
+    Task UpdatePhaseProgressAsync(UpdatePhaseProgressCommand command, CancellationToken ct = default);
+
+    /// <summary>
+    /// Marks a phase as completed and records its duration.
+    /// </summary>
+    Task CompletePhaseAsync(CompletePhaseCommand command, CancellationToken ct = default);
 }

--- a/src/KeeperData.Core.Reports/Cleanse/Operations/Command/AggregateRoots/CleanseAnalysisOperation.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Operations/Command/AggregateRoots/CleanseAnalysisOperation.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using KeeperData.Core.Reports.Cleanse.Analysis.Command.Domain;
+using KeeperData.Core.Reports.Cleanse.Operations.Queries.Dtos;
 
 namespace KeeperData.Core.Reports.Cleanse.Operations.Command.AggregateRoots;
 
@@ -95,6 +96,27 @@ public class CleanseAnalysisOperation
     public double? FinalAverageRpm { get; set; }
 
     /// <summary>
+    /// Gets or sets the name of the currently executing phase.
+    /// </summary>
+    public string? CurrentPhase { get; set; }
+
+    /// <summary>
+    /// Gets or sets the per-phase progress tracking list.
+    /// </summary>
+    public List<OperationPhaseProgress> Phases { get; set; } = [];
+
+    #region Phase weights for aggregate progress calculation
+
+    private static readonly Dictionary<string, double> PhaseWeights = new()
+    {
+        [OperationPhase.Analysis.ToString()] = 0.80,
+        [OperationPhase.Deactivation.ToString()] = 0.10,
+        [OperationPhase.Export.ToString()] = 0.10,
+    };
+
+    #endregion
+
+    /// <summary>
     /// Creates a new operation in the Running state.
     /// </summary>
     public static CleanseAnalysisOperation Create(int totalRecords = 0) => new()
@@ -103,7 +125,13 @@ public class CleanseAnalysisOperation
         Status = CleanseAnalysisStatus.Running,
         StartedAtUtc = DateTime.UtcNow,
         TotalRecords = totalRecords,
-        StatusDescription = "Initializing analysis..."
+        StatusDescription = "Initializing analysis...",
+        Phases =
+        [
+            new() { Name = OperationPhase.Analysis.ToString() },
+            new() { Name = OperationPhase.Deactivation.ToString() },
+            new() { Name = OperationPhase.Export.ToString() },
+        ]
     };
 
     /// <summary>
@@ -196,5 +224,68 @@ public class CleanseAnalysisOperation
     public void UpdateReportUrl(string reportUrl)
     {
         ReportUrl = reportUrl;
+    }
+
+    /// <summary>
+    /// Marks a phase as running and records its start time and total records.
+    /// </summary>
+    public void StartPhase(OperationPhase phase, int totalRecords)
+    {
+        var p = GetPhase(phase);
+        p.Status = "Running";
+        p.StartedAtUtc = DateTime.UtcNow;
+        p.TotalRecords = totalRecords;
+        CurrentPhase = phase.ToString();
+        StatusDescription = $"{phase} phase starting...";
+        RecalculateAggregateProgress();
+    }
+
+    /// <summary>
+    /// Updates the progress counters and description for a specific phase.
+    /// </summary>
+    public void UpdatePhaseProgress(OperationPhase phase, int recordsProcessed, int totalRecords, string description)
+    {
+        var p = GetPhase(phase);
+        p.RecordsProcessed = recordsProcessed;
+        p.TotalRecords = totalRecords;
+        p.Percentage = totalRecords > 0 ? Math.Round((double)recordsProcessed / totalRecords * 100, 2) : 0;
+        p.Description = description;
+        StatusDescription = description;
+        RecalculateAggregateProgress();
+    }
+
+    /// <summary>
+    /// Marks a phase as completed, records its end time and duration.
+    /// </summary>
+    public void CompletePhase(OperationPhase phase)
+    {
+        var p = GetPhase(phase);
+        p.Status = "Completed";
+        p.Percentage = 100.0;
+        p.CompletedAtUtc = DateTime.UtcNow;
+        p.DurationMs = p.StartedAtUtc.HasValue
+            ? (long)(p.CompletedAtUtc.Value - p.StartedAtUtc.Value).TotalMilliseconds
+            : null;
+        RecalculateAggregateProgress();
+    }
+
+    private OperationPhaseProgress GetPhase(OperationPhase phase)
+    {
+        var name = phase.ToString();
+        return Phases.Find(p => p.Name == name)
+            ?? throw new InvalidOperationException($"Phase '{name}' not found in operation '{Id}'.");
+    }
+
+    private void RecalculateAggregateProgress()
+    {
+        var aggregate = 0.0;
+        foreach (var phase in Phases)
+        {
+            if (PhaseWeights.TryGetValue(phase.Name, out var weight))
+            {
+                aggregate += weight * phase.Percentage;
+            }
+        }
+        ProgressPercentage = Math.Round(aggregate, 2);
     }
 }

--- a/src/KeeperData.Core.Reports/Cleanse/Operations/Command/CleanseOperationCommandService.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Operations/Command/CleanseOperationCommandService.cs
@@ -96,4 +96,31 @@ public class CleanseOperationCommandService(ICleanseAnalysisOperationAggRootRepo
         var operation = await repository.GetByIdAsync(operationId, ct);
         return operation?.CancellationRequested ?? false;
     }
+
+    public async Task StartPhaseAsync(StartPhaseCommand command, CancellationToken ct = default)
+    {
+        var operation = await repository.GetByIdAsync(command.OperationId, ct)
+            ?? throw new InvalidOperationException($"Operation '{command.OperationId}' not found.");
+
+        operation.StartPhase(command.Phase, command.TotalRecords);
+        await repository.UpdateAsync(operation, ct);
+    }
+
+    public async Task UpdatePhaseProgressAsync(UpdatePhaseProgressCommand command, CancellationToken ct = default)
+    {
+        var operation = await repository.GetByIdAsync(command.OperationId, ct)
+            ?? throw new InvalidOperationException($"Operation '{command.OperationId}' not found.");
+
+        operation.UpdatePhaseProgress(command.Phase, command.RecordsProcessed, command.TotalRecords, command.Description);
+        await repository.UpdateAsync(operation, ct);
+    }
+
+    public async Task CompletePhaseAsync(CompletePhaseCommand command, CancellationToken ct = default)
+    {
+        var operation = await repository.GetByIdAsync(command.OperationId, ct)
+            ?? throw new InvalidOperationException($"Operation '{command.OperationId}' not found.");
+
+        operation.CompletePhase(command.Phase);
+        await repository.UpdateAsync(operation, ct);
+    }
 }

--- a/src/KeeperData.Core.Reports/Cleanse/Operations/Command/Requests/CompletePhaseCommand.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Operations/Command/Requests/CompletePhaseCommand.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
+using KeeperData.Core.Reports.Cleanse.Analysis.Command.Domain;
+
+namespace KeeperData.Core.Reports.Cleanse.Operations.Command.Requests;
+
+[ExcludeFromCodeCoverage(Justification = "Command record - no logic to test.")]
+public record CompletePhaseCommand(
+    string OperationId,
+    OperationPhase Phase);

--- a/src/KeeperData.Core.Reports/Cleanse/Operations/Command/Requests/StartPhaseCommand.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Operations/Command/Requests/StartPhaseCommand.cs
@@ -1,0 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
+using KeeperData.Core.Reports.Cleanse.Analysis.Command.Domain;
+
+namespace KeeperData.Core.Reports.Cleanse.Operations.Command.Requests;
+
+[ExcludeFromCodeCoverage(Justification = "Command record - no logic to test.")]
+public record StartPhaseCommand(
+    string OperationId,
+    OperationPhase Phase,
+    int TotalRecords);

--- a/src/KeeperData.Core.Reports/Cleanse/Operations/Command/Requests/UpdatePhaseProgressCommand.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Operations/Command/Requests/UpdatePhaseProgressCommand.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+using KeeperData.Core.Reports.Cleanse.Analysis.Command.Domain;
+
+namespace KeeperData.Core.Reports.Cleanse.Operations.Command.Requests;
+
+[ExcludeFromCodeCoverage(Justification = "Command record - no logic to test.")]
+public record UpdatePhaseProgressCommand(
+    string OperationId,
+    OperationPhase Phase,
+    int RecordsProcessed,
+    int TotalRecords,
+    string Description);

--- a/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/Abstract/ICleanseRunStatsService.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/Abstract/ICleanseRunStatsService.cs
@@ -16,6 +16,14 @@ public interface ICleanseRunStatsService
     void RecordSnapshot(string operationId, int recordsAnalyzed);
 
     /// <summary>
+    /// Records a snapshot for a specific phase's sliding-window RPM calculation.
+    /// </summary>
+    /// <param name="operationId">The operation identifier.</param>
+    /// <param name="phaseName">The phase name.</param>
+    /// <param name="recordsProcessed">The cumulative number of records processed in this phase.</param>
+    void RecordSnapshot(string operationId, string phaseName, int recordsProcessed);
+
+    /// <summary>
     /// Calculates live performance statistics for a running operation.
     /// Returns null if the operation is not running or has no data.
     /// </summary>
@@ -25,6 +33,17 @@ public interface ICleanseRunStatsService
     /// <param name="startedAtUtc">The UTC time the operation started.</param>
     /// <returns>Live stats, or null if calculation is not possible.</returns>
     CleanseRunStatsDto? CalculateStats(string operationId, int recordsAnalyzed, int totalRecords, DateTime startedAtUtc);
+
+    /// <summary>
+    /// Calculates live performance statistics for a specific phase of a running operation.
+    /// </summary>
+    /// <param name="operationId">The operation identifier.</param>
+    /// <param name="phaseName">The phase name.</param>
+    /// <param name="recordsProcessed">The current number of records processed in this phase.</param>
+    /// <param name="totalRecords">The total number of records to process in this phase.</param>
+    /// <param name="phaseStartedAtUtc">The UTC time the phase started.</param>
+    /// <returns>Phase stats, or null if calculation is not possible.</returns>
+    PhaseStats? CalculatePhaseStats(string operationId, string phaseName, int recordsProcessed, int totalRecords, DateTime phaseStartedAtUtc);
 
     /// <summary>
     /// Removes all in-memory snapshot data for a completed or failed operation.

--- a/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/CleanseAnalysisOperationsQueries.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/CleanseAnalysisOperationsQueries.cs
@@ -58,6 +58,17 @@ public class CleanseAnalysisOperationsQueries(
         if (dto is null || (dto.Status != CleanseAnalysisStatus.Running && dto.Status != CleanseAnalysisStatus.Cancelling))
             return;
 
+        // Enrich per-phase stats for the currently running phase
+        if (dto.Phases is not null)
+        {
+            foreach (var phase in dto.Phases.Where(p => p.Status == "Running" && p.StartedAtUtc.HasValue))
+            {
+                phase.Stats = runStatsService.CalculatePhaseStats(
+                    dto.Id, phase.Name, phase.RecordsProcessed, phase.TotalRecords, phase.StartedAtUtc!.Value);
+            }
+        }
+
+        // Top-level Stats: use current phase's sliding window data for RPM, operation-wide elapsed time for average
         dto.Stats = runStatsService.CalculateStats(dto.Id, dto.RecordsAnalyzed, dto.TotalRecords, dto.StartedAtUtc);
     }
 

--- a/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/CleanseRunStatsService.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/CleanseRunStatsService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using KeeperData.Core.Reports.Cleanse.Analysis.Command.Domain;
 using KeeperData.Core.Reports.Cleanse.Operations.Queries.Abstract;
 using KeeperData.Core.Reports.Cleanse.Operations.Queries.Dtos;
 using KeeperData.Core.Throttling;
@@ -11,43 +12,70 @@ namespace KeeperData.Core.Reports.Cleanse.Operations.Queries;
 /// </summary>
 public sealed class CleanseRunStatsService(IThrottler throttler, TimeProvider timeProvider) : ICleanseRunStatsService
 {
-    private readonly record struct Snapshot(DateTime TimestampUtc, int RecordsAnalyzed);
+    private readonly record struct Snapshot(DateTime TimestampUtc, int RecordsProcessed);
 
     private readonly ConcurrentDictionary<string, ConcurrentQueue<Snapshot>> _snapshots = new();
 
     /// <inheritdoc/>
     public void RecordSnapshot(string operationId, int recordsAnalyzed)
     {
-        var queue = _snapshots.GetOrAdd(operationId, _ => new ConcurrentQueue<Snapshot>());
-        queue.Enqueue(new Snapshot(timeProvider.GetUtcNow().UtcDateTime, recordsAnalyzed));
+        RecordSnapshot(operationId, OperationPhase.Analysis.ToString(), recordsAnalyzed);
+    }
 
-        PruneOldSnapshots(queue, throttler.Settings.CleanseAnalysis.RpmWindowSeconds);
+    /// <inheritdoc/>
+    public void RecordSnapshot(string operationId, string phaseName, int recordsProcessed)
+    {
+        var key = BuildKey(operationId, phaseName);
+        var windowSeconds = GetRpmWindowSeconds(phaseName);
+        var queue = _snapshots.GetOrAdd(key, _ => new ConcurrentQueue<Snapshot>());
+        queue.Enqueue(new Snapshot(timeProvider.GetUtcNow().UtcDateTime, recordsProcessed));
+        PruneOldSnapshots(queue, windowSeconds);
     }
 
     /// <inheritdoc/>
     public CleanseRunStatsDto? CalculateStats(string operationId, int recordsAnalyzed, int totalRecords, DateTime startedAtUtc)
     {
+        var phaseStats = CalculatePhaseStats(operationId, OperationPhase.Analysis.ToString(), recordsAnalyzed, totalRecords, startedAtUtc);
+        if (phaseStats is null)
+            return null;
+
         var settings = throttler.Settings.CleanseAnalysis;
+        return new CleanseRunStatsDto
+        {
+            CurrentRpm = phaseStats.CurrentRpm,
+            AverageRpm = phaseStats.AverageRpm,
+            ProjectedEndUtc = phaseStats.ProjectedEndUtc,
+            EstimatedDurationRemainingSeconds = phaseStats.EstimatedRemainingSeconds,
+            ThrottlePolicyName = phaseStats.ThrottlePolicyName,
+            ThrottlePolicySlug = phaseStats.ThrottlePolicySlug,
+            PumpBatchSize = settings.PumpBatchSize,
+            PumpDelayMs = settings.PumpDelayMs
+        };
+    }
+
+    /// <inheritdoc/>
+    public PhaseStats? CalculatePhaseStats(string operationId, string phaseName, int recordsProcessed, int totalRecords, DateTime phaseStartedAtUtc)
+    {
+        var key = BuildKey(operationId, phaseName);
+        var windowSeconds = GetRpmWindowSeconds(phaseName);
         var now = timeProvider.GetUtcNow().UtcDateTime;
-        var elapsedMinutes = (now - startedAtUtc).TotalMinutes;
+        var elapsedMinutes = (now - phaseStartedAtUtc).TotalMinutes;
 
         var averageRpm = elapsedMinutes > 0
-            ? Math.Round(recordsAnalyzed / elapsedMinutes, 2)
+            ? Math.Round(recordsProcessed / elapsedMinutes, 2)
             : 0;
 
         double currentRpm = 0;
-        if (_snapshots.TryGetValue(operationId, out var queue))
+        if (_snapshots.TryGetValue(key, out var queue))
         {
-            PruneOldSnapshots(queue, settings.RpmWindowSeconds);
+            PruneOldSnapshots(queue, windowSeconds);
             currentRpm = CalculateWindowRpm(queue);
         }
 
         DateTime? projectedEnd = null;
         double? estimatedRemainingSeconds = null;
-        var remainingRecords = totalRecords - recordsAnalyzed;
+        var remainingRecords = totalRecords - recordsProcessed;
 
-        // Use window RPM for projection so throttle policy changes are reflected quickly.
-        // Fall back to average RPM if no window data is available yet.
         var projectionRpm = currentRpm > 0 ? currentRpm : averageRpm;
         if (projectionRpm > 0 && remainingRecords > 0)
         {
@@ -56,24 +84,49 @@ public sealed class CleanseRunStatsService(IThrottler throttler, TimeProvider ti
             estimatedRemainingSeconds = Math.Round(remainingMinutes * 60, 1);
         }
 
-        return new CleanseRunStatsDto
+        var (batchSize, batchDelayMs) = GetThrottleSettings(phaseName);
+
+        return new PhaseStats
         {
             CurrentRpm = currentRpm,
             AverageRpm = averageRpm,
             ProjectedEndUtc = projectedEnd,
-            EstimatedDurationRemainingSeconds = estimatedRemainingSeconds,
+            EstimatedRemainingSeconds = estimatedRemainingSeconds,
             ThrottlePolicyName = throttler.ActivePolicyName,
             ThrottlePolicySlug = throttler.ActivePolicySlug,
-            PumpBatchSize = settings.PumpBatchSize,
-            PumpDelayMs = settings.PumpDelayMs
+            BatchSize = batchSize,
+            BatchDelayMs = batchDelayMs
         };
     }
 
     /// <inheritdoc/>
     public void ClearSnapshots(string operationId)
     {
+        // Remove all phase-keyed entries for this operation
+        var keysToRemove = _snapshots.Keys.Where(k => k.StartsWith($"{operationId}:", StringComparison.Ordinal)).ToList();
+        foreach (var key in keysToRemove)
+        {
+            _snapshots.TryRemove(key, out _);
+        }
+        // Also remove legacy non-phased key
         _snapshots.TryRemove(operationId, out _);
     }
+
+    private static string BuildKey(string operationId, string phaseName) => $"{operationId}:{phaseName}";
+
+    private int GetRpmWindowSeconds(string phaseName) => phaseName switch
+    {
+        nameof(OperationPhase.Deactivation) => throttler.Settings.IssueDeactivation.RpmWindowSeconds,
+        nameof(OperationPhase.Export) => throttler.Settings.CleanseExport.RpmWindowSeconds,
+        _ => throttler.Settings.CleanseAnalysis.RpmWindowSeconds
+    };
+
+    private (int BatchSize, int BatchDelayMs) GetThrottleSettings(string phaseName) => phaseName switch
+    {
+        nameof(OperationPhase.Deactivation) => (throttler.Settings.IssueDeactivation.BatchSize, throttler.Settings.IssueDeactivation.ThrottleDelayMs),
+        nameof(OperationPhase.Export) => (throttler.Settings.CleanseExport.StreamBatchSize, throttler.Settings.CleanseExport.ThrottlingDelayMs),
+        _ => (throttler.Settings.CleanseAnalysis.PumpBatchSize, throttler.Settings.CleanseAnalysis.PumpDelayMs)
+    };
 
     private static double CalculateWindowRpm(ConcurrentQueue<Snapshot> queue)
     {
@@ -88,7 +141,7 @@ public sealed class CleanseRunStatsService(IThrottler throttler, TimeProvider ti
         if (windowMinutes <= 0)
             return 0;
 
-        var recordsDelta = newest.RecordsAnalyzed - oldest.RecordsAnalyzed;
+        var recordsDelta = newest.RecordsProcessed - oldest.RecordsProcessed;
         return Math.Round(recordsDelta / windowMinutes, 2);
     }
 

--- a/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/Dtos/CleanseAnalysisOperationDto.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/Dtos/CleanseAnalysisOperationDto.cs
@@ -94,6 +94,18 @@ public class CleanseAnalysisOperationDto
     public DateTime? CancelledAtUtc { get; set; }
 
     /// <summary>
+    /// Gets or sets the name of the currently executing phase.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CurrentPhase { get; set; }
+
+    /// <summary>
+    /// Gets or sets the per-phase progress breakdown.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<OperationPhaseProgress>? Phases { get; set; }
+
+    /// <summary>
     /// Gets or sets live performance statistics. Only populated for running operations.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/Dtos/CleanseAnalysisOperationSummaryDto.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/Dtos/CleanseAnalysisOperationSummaryDto.cs
@@ -83,6 +83,12 @@ public class CleanseAnalysisOperationSummaryDto
     public DateTime? CancelledAtUtc { get; set; }
 
     /// <summary>
+    /// Gets or sets the name of the currently executing phase.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CurrentPhase { get; set; }
+
+    /// <summary>
     /// Gets or sets live performance statistics. Only populated for running operations.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/Dtos/OperationPhaseProgress.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/Dtos/OperationPhaseProgress.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace KeeperData.Core.Reports.Cleanse.Operations.Queries.Dtos;
+
+/// <summary>
+/// Progress tracking for a single phase of a cleanse analysis operation.
+/// </summary>
+[ExcludeFromCodeCoverage(Justification = "DTO class - no logic to test.")]
+public class OperationPhaseProgress
+{
+    /// <summary>
+    /// Gets or sets the phase name (e.g., "Analysis", "Deactivation", "Export").
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the phase status: "NotStarted", "Running", or "Completed".
+    /// </summary>
+    public string Status { get; set; } = "NotStarted";
+
+    /// <summary>
+    /// Gets or sets the progress percentage (0-100) within this phase.
+    /// </summary>
+    public double Percentage { get; set; }
+
+    /// <summary>
+    /// Gets or sets a human-readable description of this phase's current progress.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the number of records/units processed so far in this phase.
+    /// </summary>
+    public int RecordsProcessed { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total number of records/units to process in this phase.
+    /// </summary>
+    public int TotalRecords { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC timestamp when this phase started.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? StartedAtUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC timestamp when this phase completed.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? CompletedAtUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total duration of this phase in milliseconds. Set on completion.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? DurationMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets the live performance statistics for this phase.
+    /// Populated at read-time for running phases only; not persisted.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public PhaseStats? Stats { get; set; }
+}

--- a/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/Dtos/PhaseStats.cs
+++ b/src/KeeperData.Core.Reports/Cleanse/Operations/Queries/Dtos/PhaseStats.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace KeeperData.Core.Reports.Cleanse.Operations.Queries.Dtos;
+
+/// <summary>
+/// Per-phase live performance statistics including RPM and projected completion.
+/// </summary>
+[ExcludeFromCodeCoverage(Justification = "DTO class - no logic to test.")]
+public class PhaseStats
+{
+    /// <summary>
+    /// Gets or sets the current records per minute rate based on the latest sliding window.
+    /// </summary>
+    public double CurrentRpm { get; set; }
+
+    /// <summary>
+    /// Gets or sets the average records per minute over the entire phase lifetime.
+    /// </summary>
+    public double AverageRpm { get; set; }
+
+    /// <summary>
+    /// Gets or sets the projected UTC end time for this phase based on the current window RPM.
+    /// Null if projection is not possible.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateTime? ProjectedEndUtc { get; set; }
+
+    /// <summary>
+    /// Gets or sets the estimated remaining duration in seconds for this phase.
+    /// Null if estimation is not possible.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? EstimatedRemainingSeconds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the currently active throttle policy.
+    /// </summary>
+    public string ThrottlePolicyName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the slug of the currently active throttle policy.
+    /// </summary>
+    public string ThrottlePolicySlug { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the current batch size from the active throttle policy.
+    /// </summary>
+    public int BatchSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current delay in milliseconds between batches.
+    /// </summary>
+    public int BatchDelayMs { get; set; }
+}

--- a/src/KeeperData.Core.Reports/Internal/Documents/CleanseAnalysisOperationDocument.cs
+++ b/src/KeeperData.Core.Reports/Internal/Documents/CleanseAnalysisOperationDocument.cs
@@ -28,4 +28,23 @@ internal class CleanseAnalysisOperationDocument
     [BsonElement("final_average_rpm")] public double? FinalAverageRpm { get; set; }
     [BsonElement("cancellation_requested")] public bool CancellationRequested { get; set; }
     [BsonElement("cancelled_at_utc")] public DateTime? CancelledAtUtc { get; set; }
+    [BsonElement("current_phase")] public string? CurrentPhase { get; set; }
+    [BsonElement("phases")] public List<OperationPhaseProgressDocument> Phases { get; set; } = [];
+}
+
+/// <summary>
+/// Embedded sub-document for per-phase progress tracking.
+/// </summary>
+[ExcludeFromCodeCoverage(Justification = "Internal persistence document - covered by integration tests.")]
+internal class OperationPhaseProgressDocument
+{
+    [BsonElement("name")] public string Name { get; set; } = string.Empty;
+    [BsonElement("status")] public string Status { get; set; } = "NotStarted";
+    [BsonElement("percentage")] public double Percentage { get; set; }
+    [BsonElement("description")] public string Description { get; set; } = string.Empty;
+    [BsonElement("records_processed")] public int RecordsProcessed { get; set; }
+    [BsonElement("total_records")] public int TotalRecords { get; set; }
+    [BsonElement("started_at_utc")] public DateTime? StartedAtUtc { get; set; }
+    [BsonElement("completed_at_utc")] public DateTime? CompletedAtUtc { get; set; }
+    [BsonElement("duration_ms")] public long? DurationMs { get; set; }
 }

--- a/src/KeeperData.Core.Reports/Internal/Mappers/CleanseAnalysisOperationDocumentMapper.cs
+++ b/src/KeeperData.Core.Reports/Internal/Mappers/CleanseAnalysisOperationDocumentMapper.cs
@@ -30,7 +30,9 @@ internal static class CleanseAnalysisOperationDocumentMapper
         ReportUrl = operation.ReportUrl,
         FinalAverageRpm = operation.FinalAverageRpm,
         CancellationRequested = operation.CancellationRequested,
-        CancelledAtUtc = operation.CancelledAtUtc
+        CancelledAtUtc = operation.CancelledAtUtc,
+        CurrentPhase = operation.CurrentPhase,
+        Phases = operation.Phases.Select(ToPhaseDocument).ToList()
     };
 
     public static CleanseAnalysisOperation ToAggregateRoot(this CleanseAnalysisOperationDocument doc) => new()
@@ -51,7 +53,9 @@ internal static class CleanseAnalysisOperationDocumentMapper
         ReportUrl = doc.ReportUrl,
         FinalAverageRpm = doc.FinalAverageRpm,
         CancellationRequested = doc.CancellationRequested,
-        CancelledAtUtc = doc.CancelledAtUtc
+        CancelledAtUtc = doc.CancelledAtUtc,
+        CurrentPhase = doc.CurrentPhase,
+        Phases = doc.Phases.Select(ToPhaseProgress).ToList()
     };
 
     public static CleanseAnalysisOperationDto ToDto(this CleanseAnalysisOperationDocument doc) => new()
@@ -71,7 +75,9 @@ internal static class CleanseAnalysisOperationDocumentMapper
         ReportObjectKey = doc.ReportObjectKey,
         ReportUrl = doc.ReportUrl,
         FinalAverageRpm = doc.FinalAverageRpm,
-        CancelledAtUtc = doc.CancelledAtUtc
+        CancelledAtUtc = doc.CancelledAtUtc,
+        CurrentPhase = doc.CurrentPhase,
+        Phases = doc.Phases.Count > 0 ? doc.Phases.Select(ToPhaseProgress).ToList() : null
     };
 
     public static CleanseAnalysisOperationSummaryDto ToSummaryDto(this CleanseAnalysisOperationDocument doc) => new()
@@ -89,6 +95,33 @@ internal static class CleanseAnalysisOperationDocumentMapper
         ReportObjectKey = doc.ReportObjectKey,
         ReportUrl = doc.ReportUrl,
         FinalAverageRpm = doc.FinalAverageRpm,
-        CancelledAtUtc = doc.CancelledAtUtc
+        CancelledAtUtc = doc.CancelledAtUtc,
+        CurrentPhase = doc.CurrentPhase
+    };
+
+    private static OperationPhaseProgressDocument ToPhaseDocument(OperationPhaseProgress p) => new()
+    {
+        Name = p.Name,
+        Status = p.Status,
+        Percentage = p.Percentage,
+        Description = p.Description,
+        RecordsProcessed = p.RecordsProcessed,
+        TotalRecords = p.TotalRecords,
+        StartedAtUtc = p.StartedAtUtc,
+        CompletedAtUtc = p.CompletedAtUtc,
+        DurationMs = p.DurationMs
+    };
+
+    private static OperationPhaseProgress ToPhaseProgress(OperationPhaseProgressDocument d) => new()
+    {
+        Name = d.Name,
+        Status = d.Status,
+        Percentage = d.Percentage,
+        Description = d.Description,
+        RecordsProcessed = d.RecordsProcessed,
+        TotalRecords = d.TotalRecords,
+        StartedAtUtc = d.StartedAtUtc,
+        CompletedAtUtc = d.CompletedAtUtc,
+        DurationMs = d.DurationMs
     };
 }

--- a/src/KeeperData.Core.Reports/Issues/Command/Abstract/IIssueAggRootRepository.cs
+++ b/src/KeeperData.Core.Reports/Issues/Command/Abstract/IIssueAggRootRepository.cs
@@ -20,8 +20,11 @@ public interface IIssueAggRootRepository
     /// <summary>
     /// Deactivates all active issues whose OperationId does not match the specified current operation.
     /// </summary>
+    /// <param name="currentOperationId">The current operation identifier.</param>
+    /// <param name="onBatchProcessed">Optional callback invoked after each batch with (deactivatedSoFar, totalStale).</param>
+    /// <param name="ct">Cancellation token.</param>
     /// <returns>The number of issues deactivated.</returns>
-    Task<int> DeactivateStaleAsync(string currentOperationId, CancellationToken ct = default);
+    Task<int> DeactivateStaleAsync(string currentOperationId, Func<int, int, Task>? onBatchProcessed, CancellationToken ct = default);
 
     /// <summary>
     /// Deletes all issues.

--- a/src/KeeperData.Core.Reports/Issues/Command/Abstract/IIssueCommandService.cs
+++ b/src/KeeperData.Core.Reports/Issues/Command/Abstract/IIssueCommandService.cs
@@ -13,8 +13,11 @@ public interface IIssueCommandService
     /// <summary>
     /// Deactivates all issues that were not touched by the specified operation.
     /// </summary>
+    /// <param name="command">The deactivation command.</param>
+    /// <param name="onBatchProcessed">Optional callback invoked after each batch with (deactivatedSoFar, totalStale).</param>
+    /// <param name="ct">Cancellation token.</param>
     /// <returns>The number of issues deactivated.</returns>
-    Task<int> DeactivateStaleIssuesAsync(DeactivateStaleIssuesCommand command, CancellationToken ct);
+    Task<int> DeactivateStaleIssuesAsync(DeactivateStaleIssuesCommand command, Func<int, int, Task>? onBatchProcessed, CancellationToken ct);
 
     /// <summary>
     /// Flags an issue as ignored.

--- a/src/KeeperData.Core.Reports/Issues/Command/IssueCommandService.cs
+++ b/src/KeeperData.Core.Reports/Issues/Command/IssueCommandService.cs
@@ -44,8 +44,8 @@ public class IssueCommandService(IIssueAggRootRepository repo, IIssueHistoryAggR
         return wasInactive ? IssueRecordResult.Reactivated : IssueRecordResult.NoChange;
     }
 
-    public async Task<int> DeactivateStaleIssuesAsync(DeactivateStaleIssuesCommand command, CancellationToken ct)
-        => await repo.DeactivateStaleAsync(command.OperationId, ct);
+    public async Task<int> DeactivateStaleIssuesAsync(DeactivateStaleIssuesCommand command, Func<int, int, Task>? onBatchProcessed, CancellationToken ct)
+        => await repo.DeactivateStaleAsync(command.OperationId, onBatchProcessed, ct);
 
     public async Task IgnoreIssueAsync(IgnoreIssueCommand command, CancellationToken ct)
     {

--- a/src/KeeperData.Core.Reports/Issues/Command/Repositories/IssueAggRootRepository.cs
+++ b/src/KeeperData.Core.Reports/Issues/Command/Repositories/IssueAggRootRepository.cs
@@ -35,7 +35,7 @@ public class IssueAggRootRepository(IssueCollection issueCollection,
         await _collection.ReplaceOneAsync(filter, item.ToDocument(), options, ct);
     }
 
-    public async Task<int> DeactivateStaleAsync(string currentOperationId, CancellationToken ct = default)
+    public async Task<int> DeactivateStaleAsync(string currentOperationId, Func<int, int, Task>? onBatchProcessed, CancellationToken ct = default)
     {
         logger.LogInformation("Deactivating stale issues: starting (OperationId={OperationId})", currentOperationId);
         var stopwatch = Stopwatch.StartNew();
@@ -44,6 +44,7 @@ public class IssueAggRootRepository(IssueCollection issueCollection,
             Builders<IssueDocument>.Filter.Eq(d => d.IsActive, true),
             Builders<IssueDocument>.Filter.Ne(d => d.OperationId, currentOperationId));
 
+        var totalStale = (int)await _collection.CountDocumentsAsync(staleFilter, cancellationToken: ct);
         var totalDeactivated = 0;
 
         while (!ct.IsCancellationRequested)
@@ -70,6 +71,11 @@ public class IssueAggRootRepository(IssueCollection issueCollection,
 
             var result = await _collection.UpdateManyAsync(batchFilter, update, cancellationToken: ct);
             totalDeactivated += (int)result.ModifiedCount;
+
+            if (onBatchProcessed is not null)
+            {
+                await onBatchProcessed(totalDeactivated, totalStale);
+            }
 
             if (staleIds.Count < settings.BatchSize)
             {

--- a/src/KeeperData.Core/Throttling/Models/CleanseExportThrottleSettings.cs
+++ b/src/KeeperData.Core/Throttling/Models/CleanseExportThrottleSettings.cs
@@ -7,10 +7,12 @@ public sealed record CleanseExportThrottleSettings
 {
     public int StreamBatchSize { get; init; } = Defaults.StreamBatchSize;
     public int ThrottlingDelayMs { get; init; } = Defaults.ThrottlingDelayMs;
+    public int RpmWindowSeconds { get; init; } = Defaults.RpmWindowSeconds;
 
     public static class Defaults
     {
         public const int StreamBatchSize = 500;
         public const int ThrottlingDelayMs = 250;
+        public const int RpmWindowSeconds = 30;
     }
 }

--- a/src/KeeperData.Core/Throttling/Models/IssueDeactivationThrottleSettings.cs
+++ b/src/KeeperData.Core/Throttling/Models/IssueDeactivationThrottleSettings.cs
@@ -7,10 +7,12 @@ public sealed record IssueDeactivationThrottleSettings
 {
     public int BatchSize { get; init; } = Defaults.BatchSize;
     public int ThrottleDelayMs { get; init; } = Defaults.ThrottleDelayMs;
+    public int RpmWindowSeconds { get; init; } = Defaults.RpmWindowSeconds;
 
     public static class Defaults
     {
         public const int BatchSize = 200;
         public const int ThrottleDelayMs = 500;
+        public const int RpmWindowSeconds = 30;
     }
 }

--- a/tests/KeeperData.Core.Tests.Unit/CleanseReporting/Cleanse/Operations/Command/AggregateRoots/CleanseAnalysisOperationTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/CleanseReporting/Cleanse/Operations/Command/AggregateRoots/CleanseAnalysisOperationTests.cs
@@ -142,4 +142,124 @@ public class CleanseAnalysisOperationTests
 
         op.TotalRecords.Should().Be(1000);
     }
+
+    #region Phase tracking
+
+    [Fact]
+    public void Create_ShouldInitialiseThreeNotStartedPhases()
+    {
+        var op = CleanseAnalysisOperation.Create();
+
+        op.Phases.Should().HaveCount(3);
+        op.Phases.Should().AllSatisfy(p => p.Status.Should().Be("NotStarted"));
+        op.Phases.Select(p => p.Name).Should().ContainInOrder("Analysis", "Deactivation", "Export");
+    }
+
+    [Fact]
+    public void StartPhase_ShouldSetRunningStatusAndCurrentPhase()
+    {
+        var op = CleanseAnalysisOperation.Create();
+
+        op.StartPhase(OperationPhase.Analysis, 1000);
+
+        var phase = op.Phases.Single(p => p.Name == "Analysis");
+        phase.Status.Should().Be("Running");
+        phase.TotalRecords.Should().Be(1000);
+        phase.StartedAtUtc.Should().NotBeNull();
+        op.CurrentPhase.Should().Be("Analysis");
+    }
+
+    [Fact]
+    public void UpdatePhaseProgress_ShouldUpdateCountersAndPercentage()
+    {
+        var op = CleanseAnalysisOperation.Create();
+        op.StartPhase(OperationPhase.Analysis, 1000);
+
+        op.UpdatePhaseProgress(OperationPhase.Analysis, 500, 1000, "Halfway");
+
+        var phase = op.Phases.Single(p => p.Name == "Analysis");
+        phase.RecordsProcessed.Should().Be(500);
+        phase.Percentage.Should().Be(50.0);
+        phase.Description.Should().Be("Halfway");
+        op.StatusDescription.Should().Be("Halfway");
+    }
+
+    [Fact]
+    public void UpdatePhaseProgress_ShouldRecalculateAggregatePercentage()
+    {
+        var op = CleanseAnalysisOperation.Create();
+        op.StartPhase(OperationPhase.Analysis, 1000);
+
+        op.UpdatePhaseProgress(OperationPhase.Analysis, 500, 1000, "Halfway");
+
+        // Analysis weight = 0.80, 50% of 80 = 40
+        op.ProgressPercentage.Should().Be(40.0);
+    }
+
+    [Fact]
+    public void CompletePhase_ShouldSetCompletedStatusAndDuration()
+    {
+        var op = CleanseAnalysisOperation.Create();
+        op.StartPhase(OperationPhase.Analysis, 1000);
+
+        op.CompletePhase(OperationPhase.Analysis);
+
+        var phase = op.Phases.Single(p => p.Name == "Analysis");
+        phase.Status.Should().Be("Completed");
+        phase.Percentage.Should().Be(100.0);
+        phase.CompletedAtUtc.Should().NotBeNull();
+        phase.DurationMs.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CompletePhase_ShouldRecalculateAggregate()
+    {
+        var op = CleanseAnalysisOperation.Create();
+        op.StartPhase(OperationPhase.Analysis, 1000);
+        op.CompletePhase(OperationPhase.Analysis);
+
+        // Analysis=100% * 0.80 = 80, others=0
+        op.ProgressPercentage.Should().Be(80.0);
+    }
+
+    [Fact]
+    public void CompleteAllPhases_ShouldReach100Percent()
+    {
+        var op = CleanseAnalysisOperation.Create();
+
+        op.StartPhase(OperationPhase.Analysis, 100);
+        op.CompletePhase(OperationPhase.Analysis);
+        op.StartPhase(OperationPhase.Deactivation, 50);
+        op.CompletePhase(OperationPhase.Deactivation);
+        op.StartPhase(OperationPhase.Export, 30);
+        op.CompletePhase(OperationPhase.Export);
+
+        op.ProgressPercentage.Should().Be(100.0);
+    }
+
+    [Fact]
+    public void StartPhase_WithUnknownPhase_ShouldThrow()
+    {
+        var op = CleanseAnalysisOperation.Create();
+        // Remove all phases to simulate a missing phase
+        op.Phases.Clear();
+
+        var act = () => op.StartPhase(OperationPhase.Analysis, 100);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not found*");
+    }
+
+    [Fact]
+    public void UpdatePhaseProgress_WithZeroTotal_ShouldSetZeroPercentage()
+    {
+        var op = CleanseAnalysisOperation.Create();
+        op.StartPhase(OperationPhase.Deactivation, 0);
+
+        op.UpdatePhaseProgress(OperationPhase.Deactivation, 0, 0, "No stale issues");
+
+        var phase = op.Phases.Single(p => p.Name == "Deactivation");
+        phase.Percentage.Should().Be(0);
+    }
+
+    #endregion
 }

--- a/tests/KeeperData.Core.Tests.Unit/CleanseReporting/Cleanse/Operations/Command/CleanseOperationCommandServiceTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/CleanseReporting/Cleanse/Operations/Command/CleanseOperationCommandServiceTests.cs
@@ -183,4 +183,69 @@ public class CleanseOperationCommandServiceTests
 
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*not found*");
     }
+
+    #region Phase commands
+
+    [Fact]
+    public async Task StartPhaseAsync_ShouldSetPhaseRunningAndPersist()
+    {
+        var operation = CleanseAnalysisOperation.Create();
+        _repoMock.Setup(r => r.GetByIdAsync(operation.Id, It.IsAny<CancellationToken>())).ReturnsAsync(operation);
+
+        await _sut.StartPhaseAsync(
+            new StartPhaseCommand(operation.Id, OperationPhase.Analysis, 500), CancellationToken.None);
+
+        var phase = operation.Phases.Single(p => p.Name == "Analysis");
+        phase.Status.Should().Be("Running");
+        phase.TotalRecords.Should().Be(500);
+        operation.CurrentPhase.Should().Be("Analysis");
+        _repoMock.Verify(r => r.UpdateAsync(operation, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdatePhaseProgressAsync_ShouldUpdatePhaseAndPersist()
+    {
+        var operation = CleanseAnalysisOperation.Create();
+        operation.StartPhase(OperationPhase.Deactivation, 100);
+        _repoMock.Setup(r => r.GetByIdAsync(operation.Id, It.IsAny<CancellationToken>())).ReturnsAsync(operation);
+
+        await _sut.UpdatePhaseProgressAsync(
+            new UpdatePhaseProgressCommand(operation.Id, OperationPhase.Deactivation, 50, 100, "Half done"),
+            CancellationToken.None);
+
+        var phase = operation.Phases.Single(p => p.Name == "Deactivation");
+        phase.RecordsProcessed.Should().Be(50);
+        phase.Percentage.Should().Be(50.0);
+        _repoMock.Verify(r => r.UpdateAsync(operation, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompletePhaseAsync_ShouldSetPhaseCompletedAndPersist()
+    {
+        var operation = CleanseAnalysisOperation.Create();
+        operation.StartPhase(OperationPhase.Export, 200);
+        _repoMock.Setup(r => r.GetByIdAsync(operation.Id, It.IsAny<CancellationToken>())).ReturnsAsync(operation);
+
+        await _sut.CompletePhaseAsync(
+            new CompletePhaseCommand(operation.Id, OperationPhase.Export), CancellationToken.None);
+
+        var phase = operation.Phases.Single(p => p.Name == "Export");
+        phase.Status.Should().Be("Completed");
+        phase.Percentage.Should().Be(100.0);
+        phase.CompletedAtUtc.Should().NotBeNull();
+        _repoMock.Verify(r => r.UpdateAsync(operation, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartPhaseAsync_WhenNotFound_ShouldThrow()
+    {
+        _repoMock.Setup(r => r.GetByIdAsync("missing", It.IsAny<CancellationToken>())).ReturnsAsync((CleanseAnalysisOperation?)null);
+
+        var act = () => _sut.StartPhaseAsync(
+            new StartPhaseCommand("missing", OperationPhase.Analysis, 0), CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*not found*");
+    }
+
+    #endregion
 }

--- a/tests/KeeperData.Core.Tests.Unit/CleanseReporting/Cleanse/Operations/Queries/CleanseRunStatsServiceTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/CleanseReporting/Cleanse/Operations/Queries/CleanseRunStatsServiceTests.cs
@@ -203,4 +203,124 @@ public class CleanseRunStatsServiceTests
     }
 
     #endregion
+
+    #region Phase-keyed snapshots and stats
+
+    [Fact]
+    public void RecordSnapshot_WithPhaseName_ShouldAccumulatePerPhase()
+    {
+        _sut.RecordSnapshot("op-1", "Analysis", 100);
+        _timeProvider.Advance(TimeSpan.FromSeconds(10));
+        _sut.RecordSnapshot("op-1", "Analysis", 200);
+
+        var stats = _sut.CalculatePhaseStats("op-1", "Analysis",
+            recordsProcessed: 200, totalRecords: 1000,
+            phaseStartedAtUtc: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-1));
+
+        stats.Should().NotBeNull();
+        stats!.CurrentRpm.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void CalculatePhaseStats_WithNoSnapshots_ShouldReturnZeroCurrentRpm()
+    {
+        var stats = _sut.CalculatePhaseStats("op-1", "Deactivation",
+            recordsProcessed: 50, totalRecords: 100,
+            phaseStartedAtUtc: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-1));
+
+        stats.Should().NotBeNull();
+        stats!.CurrentRpm.Should().Be(0);
+        stats.AverageRpm.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void CalculatePhaseStats_ShouldReturnThrottleSettingsForPhase()
+    {
+        var deactivationStats = _sut.CalculatePhaseStats("op-1", "Deactivation",
+            recordsProcessed: 50, totalRecords: 100,
+            phaseStartedAtUtc: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-1));
+
+        deactivationStats.Should().NotBeNull();
+        deactivationStats!.BatchSize.Should().Be(_throttler.Settings.IssueDeactivation.BatchSize);
+        deactivationStats.BatchDelayMs.Should().Be(_throttler.Settings.IssueDeactivation.ThrottleDelayMs);
+    }
+
+    [Fact]
+    public void CalculatePhaseStats_ForExport_ShouldReturnExportThrottleSettings()
+    {
+        var exportStats = _sut.CalculatePhaseStats("op-1", "Export",
+            recordsProcessed: 100, totalRecords: 500,
+            phaseStartedAtUtc: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-1));
+
+        exportStats.Should().NotBeNull();
+        exportStats!.BatchSize.Should().Be(_throttler.Settings.CleanseExport.StreamBatchSize);
+        exportStats.BatchDelayMs.Should().Be(_throttler.Settings.CleanseExport.ThrottlingDelayMs);
+    }
+
+    [Fact]
+    public void CalculatePhaseStats_WhenAllProcessed_ShouldReturnNullProjection()
+    {
+        var stats = _sut.CalculatePhaseStats("op-1", "Analysis",
+            recordsProcessed: 1000, totalRecords: 1000,
+            phaseStartedAtUtc: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-5));
+
+        stats.Should().NotBeNull();
+        stats!.ProjectedEndUtc.Should().BeNull();
+        stats.EstimatedRemainingSeconds.Should().BeNull();
+    }
+
+    [Fact]
+    public void ClearSnapshots_ShouldRemoveAllPhaseKeysForOperation()
+    {
+        _sut.RecordSnapshot("op-1", "Analysis", 100);
+        _sut.RecordSnapshot("op-1", "Deactivation", 50);
+        _timeProvider.Advance(TimeSpan.FromSeconds(10));
+        _sut.RecordSnapshot("op-1", "Analysis", 200);
+        _sut.RecordSnapshot("op-1", "Deactivation", 100);
+
+        _sut.ClearSnapshots("op-1");
+
+        var analysisStats = _sut.CalculatePhaseStats("op-1", "Analysis",
+            recordsProcessed: 200, totalRecords: 1000,
+            phaseStartedAtUtc: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-1));
+        analysisStats!.CurrentRpm.Should().Be(0, "snapshots were cleared");
+
+        var deactivationStats = _sut.CalculatePhaseStats("op-1", "Deactivation",
+            recordsProcessed: 100, totalRecords: 200,
+            phaseStartedAtUtc: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-1));
+        deactivationStats!.CurrentRpm.Should().Be(0, "snapshots were cleared");
+    }
+
+    [Fact]
+    public void ClearSnapshots_ShouldNotAffectOtherOperationPhases()
+    {
+        _sut.RecordSnapshot("op-1", "Analysis", 100);
+        _sut.RecordSnapshot("op-2", "Analysis", 100);
+        _timeProvider.Advance(TimeSpan.FromSeconds(10));
+        _sut.RecordSnapshot("op-2", "Analysis", 200);
+
+        _sut.ClearSnapshots("op-1");
+
+        var stats = _sut.CalculatePhaseStats("op-2", "Analysis",
+            recordsProcessed: 200, totalRecords: 1000,
+            phaseStartedAtUtc: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-1));
+        stats!.CurrentRpm.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void LegacyRecordSnapshot_ShouldDelegateToAnalysisPhase()
+    {
+        // The legacy overload should work via the phase-keyed system
+        _sut.RecordSnapshot("op-1", 100);
+        _timeProvider.Advance(TimeSpan.FromSeconds(10));
+        _sut.RecordSnapshot("op-1", 200);
+
+        var phaseStats = _sut.CalculatePhaseStats("op-1", "Analysis",
+            recordsProcessed: 200, totalRecords: 1000,
+            phaseStartedAtUtc: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-1));
+
+        phaseStats!.CurrentRpm.Should().BeGreaterThan(0);
+    }
+
+    #endregion
 }

--- a/tests/KeeperData.Core.Tests.Unit/CleanseReporting/Issues/Command/IssueCommandServiceTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/CleanseReporting/Issues/Command/IssueCommandServiceTests.cs
@@ -72,10 +72,10 @@ public class IssueCommandServiceTests
     [Fact]
     public async Task DeactivateStaleIssuesAsync_ShouldDelegateToRepository()
     {
-        _repoMock.Setup(r => r.DeactivateStaleAsync("op-1", It.IsAny<CancellationToken>()))
+        _repoMock.Setup(r => r.DeactivateStaleAsync("op-1", null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(3);
 
-        var result = await _sut.DeactivateStaleIssuesAsync(new DeactivateStaleIssuesCommand("op-1"), CancellationToken.None);
+        var result = await _sut.DeactivateStaleIssuesAsync(new DeactivateStaleIssuesCommand("op-1"), null, CancellationToken.None);
 
         result.Should().Be(3);
     }


### PR DESCRIPTION
The problem was the progress reporting only surfaced the progress information for phase 1 of 3 of the cleanse analysis and reporting activity; hence the delay observed, which is when phases 2 and 3 invisibly execute. The fix is to split the progress reporting into the three phases (analysis, stale issues processing and report-generation) and expose an aggregated level of progress reporting.