### PR TITLE
Add 5-digit CPH validation for amls2_port ingestion

### DIFF
--- a/src/KeeperData.Bridge.PerformanceTests/PerformanceTests.cs
+++ b/src/KeeperData.Bridge.PerformanceTests/PerformanceTests.cs
@@ -323,6 +323,12 @@ public class PerformanceTests : IAsyncLifetime
             SamCPHHolder = dataSetDefinition,
             SamHerd = dataSetDefinition,
             SamParty = dataSetDefinition,
+            SamTla = dataSetDefinition,
+            Amls2CommonLand = dataSetDefinition,
+            Amls2Port = dataSetDefinition,
+            CtsAgent = dataSetDefinition,
+            AmesHaulier = dataSetDefinition,
+            SamShowground = dataSetDefinition,
             All = [dataSetDefinition]
         };
         services.AddSingleton<Core.ETL.Abstract.IDataSetDefinitions>(dataSetDefinitions);

--- a/src/KeeperData.Core/ETL/Impl/IngestionPipeline.cs
+++ b/src/KeeperData.Core/ETL/Impl/IngestionPipeline.cs
@@ -128,8 +128,7 @@ public class IngestionPipeline(
         var totalFiles = fileSets.Sum(fs => fs.Files.Length);
 
         Debug.WriteLine($"[keepetl] Discovered {fileSets.Count} file set(s) containing {totalFiles} file(s) for ImportId: {importId}");
-        logger.LogInformation("Discovered {FileSetCount} file set(s) containing {TotalFileCount} file(s) for ImportId: {importId}", fileSets.Count, totalFiles, importId);
-
+        logger.LogInformation("Discovered {FileSetCount} file set(s) containing {TotalFileCount} file(s) for ImportId: {ImportId}", fileSets.Count, totalFiles, importId);
         return (fileSets, totalFiles);
     }
 
@@ -476,29 +475,10 @@ public class IngestionPipeline(
         {
             var changeType = csv.GetField(headers.ChangeTypeHeaderName)?.ToUpperInvariant() ?? string.Empty;
 
-            if (!IsValidChangeType(changeType))
+            // Validate record - skip if invalid
+            if (!TryValidateRecord(changeType, collectionName, csv, headers, fileKey, fileMetrics))
             {
-                var primaryKeyValue = string.Join(EtlConstants.CompositeKeyDelimiter, headers.PrimaryKeyHeaderNames.Select(pkHeader => csv.GetField(pkHeader) ?? string.Empty));
-                Debug.WriteLine($"[keepetl] Invalid change type '{changeType}' for record with primary key '{primaryKeyValue}' in file {fileKey}, skipping record");
-                logger.LogWarning("Invalid change type '{ChangeType}' for record with primary key '{PrimaryKey}' in file {FileKey}, skipping record",
-                    changeType, primaryKeyValue, fileKey);
-                fileMetrics.RecordsSkipped++;
                 continue;
-            }
-
-            // Validate CPH format for amls2_port collection
-            if (collectionName == "amls2_port")
-            {
-                var cphValue = csv.GetField("CPH");
-                if (!IsValid5DigitCph(cphValue))
-                {
-                    var primaryKeyValue = string.Join(EtlConstants.CompositeKeyDelimiter, headers.PrimaryKeyHeaderNames.Select(pkHeader => csv.GetField(pkHeader) ?? string.Empty));
-                    Debug.WriteLine($"[keepetl] Invalid CPH format '{cphValue}' (expected 5 digits) for record with primary key '{primaryKeyValue}' in file {fileKey}, skipping record");
-                    logger.LogWarning("Invalid CPH format '{CPH}' (expected 5 digits) for record with primary key '{PrimaryKey}' in file {FileKey}, skipping record",
-                        cphValue, primaryKeyValue, fileKey);
-                    fileMetrics.RecordsSkipped++;
-                    continue;
-                }
             }
 
             var document = CreateDocumentFromCsvRecord(csv, headers, definition);
@@ -507,44 +487,11 @@ public class IngestionPipeline(
             var ingestionSettings = throttler.Settings.Ingestion;
             if (batch.Count >= ingestionSettings.BatchSize)
             {
-                var batchStopwatch = Stopwatch.StartNew();
-                Debug.WriteLine($"[keepetl] -- NEW BATCH (size:{ingestionSettings.BatchSize}) --");
-                Debug.WriteLine($"[keepetl] Processing batch of {batch.Count} documents for collection {collectionName}");
-
-                var batchMetrics = await ProcessBatchAsync(importId, collection, batch, fileKey, collectionName, definition, lineageEvents, ct);
-
-                await FlushLineageEventsAsync(lineageEvents, ct);
-
-                var batchDto = new KeeperData.Core.Reporting.Dtos.BatchProcessingMetrics
-                {
-                    RecordsProcessed = batchMetrics.RecordsProcessed,
-                    RecordsCreated = batchMetrics.RecordsCreated,
-                    RecordsUpdated = batchMetrics.RecordsUpdated,
-                    RecordsDeleted = batchMetrics.RecordsDeleted
-                };
-                fileMetrics.AddBatch(batchDto);
-                totals = totals.Add(new IngestionTotals
-                {
-                    RecordsCreated = batchMetrics.RecordsCreated,
-                    RecordsUpdated = batchMetrics.RecordsUpdated,
-                    RecordsDeleted = batchMetrics.RecordsDeleted
-                });
-
-                batchStopwatch.Stop();
-                totalMongoProcessingMs += batchStopwatch.ElapsedMilliseconds;
-
-                Debug.WriteLine($"[keepetl] Processed batch of {ingestionSettings.BatchSize} records from {fileKey} in {batchStopwatch.ElapsedMilliseconds}ms. Total processed: {fileMetrics.RecordsProcessed}, Created: {fileMetrics.RecordsCreated}, Updated: {fileMetrics.RecordsUpdated}, Deleted: {fileMetrics.RecordsDeleted}");
-                Debug.WriteLine($"[keepetl] -- END BATCH ({batchStopwatch.Elapsed.TotalSeconds}s, {batchStopwatch.ElapsedMilliseconds}ms) --");
-
-                if (ingestionSettings.BatchDelayMs > 0)
-                {
-                    Debug.WriteLine($"[keepetl] Throttling: waiting {ingestionSettings.BatchDelayMs}ms before next batch");
-                    await throttler.DelayAsync(ingestionSettings.BatchDelayMs, ct);
-                }
-
-                Debug.WriteLine($"[keepetl] ");
-
-                batch.Clear();
+                var (elapsed, updatedTotals) = await ProcessAndClearBatchAsync(
+                    importId, collection, batch, fileKey, collectionName, definition,
+                    lineageEvents, fileMetrics, totals, ct);
+                totalMongoProcessingMs += elapsed;
+                totals = updatedTotals;
             }
 
             if (fileMetrics.RecordsProcessed > lastReportedRecordCount &&
@@ -629,6 +576,99 @@ public class IngestionPipeline(
 
         // CPH should be exactly 5 digits
         return cphValue.Length == 5 && cphValue.All(char.IsDigit);
+    }
+
+    private bool TryValidateRecord(
+        string changeType,
+        string collectionName,
+        CsvReader csv,
+        CsvHeaders headers,
+        string fileKey,
+        FileMetricsTracker fileMetrics)
+    {
+        // Validate change type
+        if (!IsValidChangeType(changeType))
+        {
+            var primaryKeyValue = string.Join(EtlConstants.CompositeKeyDelimiter,
+                headers.PrimaryKeyHeaderNames.Select(pkHeader => csv.GetField(pkHeader) ?? string.Empty));
+            Debug.WriteLine($"[keepetl] Invalid change type '{changeType}' for record with primary key '{primaryKeyValue}' in file {fileKey}, skipping record");
+            logger.LogWarning("Invalid change type '{ChangeType}' for record with primary key '{PrimaryKey}' in file {FileKey}, skipping record",
+                changeType, primaryKeyValue, fileKey);
+            fileMetrics.RecordsSkipped++;
+            return false;
+        }
+
+        // Validate CPH format for amls2_port collection
+        if (collectionName == "amls2_port")
+        {
+            var cphValue = csv.GetField("CPH");
+            if (!IsValid5DigitCph(cphValue))
+            {
+                var primaryKeyValue = string.Join(EtlConstants.CompositeKeyDelimiter,
+                    headers.PrimaryKeyHeaderNames.Select(pkHeader => csv.GetField(pkHeader) ?? string.Empty));
+                Debug.WriteLine($"[keepetl] Invalid CPH format '{cphValue}' (expected 5 digits) for record with primary key '{primaryKeyValue}' in file {fileKey}, skipping record");
+                logger.LogWarning("Invalid CPH format '{CPH}' (expected 5 digits) for record with primary key '{PrimaryKey}' in file {FileKey}, skipping record",
+                    cphValue, primaryKeyValue, fileKey);
+                fileMetrics.RecordsSkipped++;
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private async Task<(long ElapsedMs, IngestionTotals UpdatedTotals)> ProcessAndClearBatchAsync(
+        Guid importId,
+        IMongoCollection<BsonDocument> collection,
+        List<(BsonDocument Document, string ChangeType)> batch,
+        string fileKey,
+        string collectionName,
+        DataSetDefinition definition,
+        List<RecordLineageEvent> lineageEvents,
+        FileMetricsTracker fileMetrics,
+        IngestionTotals totals,
+        CancellationToken ct)
+    {
+        var ingestionSettings = throttler.Settings.Ingestion;
+        var batchStopwatch = Stopwatch.StartNew();
+
+        Debug.WriteLine($"[keepetl] -- NEW BATCH (size:{ingestionSettings.BatchSize}) --");
+        Debug.WriteLine($"[keepetl] Processing batch of {batch.Count} documents for collection {collectionName}");
+
+        var batchMetrics = await ProcessBatchAsync(importId, collection, batch, fileKey, collectionName, definition, lineageEvents, ct);
+        await FlushLineageEventsAsync(lineageEvents, ct);
+
+        var batchDto = new KeeperData.Core.Reporting.Dtos.BatchProcessingMetrics
+        {
+            RecordsProcessed = batchMetrics.RecordsProcessed,
+            RecordsCreated = batchMetrics.RecordsCreated,
+            RecordsUpdated = batchMetrics.RecordsUpdated,
+            RecordsDeleted = batchMetrics.RecordsDeleted
+        };
+        fileMetrics.AddBatch(batchDto);
+
+        var updatedTotals = totals.Add(new IngestionTotals
+        {
+            RecordsCreated = batchMetrics.RecordsCreated,
+            RecordsUpdated = batchMetrics.RecordsUpdated,
+            RecordsDeleted = batchMetrics.RecordsDeleted
+        });
+
+        batchStopwatch.Stop();
+
+        Debug.WriteLine($"[keepetl] Processed batch of {ingestionSettings.BatchSize} records from {fileKey} in {batchStopwatch.ElapsedMilliseconds}ms. Total processed: {fileMetrics.RecordsProcessed}, Created: {fileMetrics.RecordsCreated}, Updated: {fileMetrics.RecordsUpdated}, Deleted: {fileMetrics.RecordsDeleted}");
+        Debug.WriteLine($"[keepetl] -- END BATCH ({batchStopwatch.Elapsed.TotalSeconds}s, {batchStopwatch.ElapsedMilliseconds}ms) --");
+
+        if (ingestionSettings.BatchDelayMs > 0)
+        {
+            Debug.WriteLine($"[keepetl] Throttling: waiting {ingestionSettings.BatchDelayMs}ms before next batch");
+            await throttler.DelayAsync(ingestionSettings.BatchDelayMs, ct);
+        }
+
+        Debug.WriteLine($"[keepetl] ");
+        batch.Clear();
+
+        return (batchStopwatch.ElapsedMilliseconds, updatedTotals);
     }
 
     private void LogProgressIfNeeded(int recordsProcessed, string fileKey)

--- a/src/KeeperData.Core/ETL/Impl/IngestionPipeline.cs
+++ b/src/KeeperData.Core/ETL/Impl/IngestionPipeline.cs
@@ -486,6 +486,21 @@ public class IngestionPipeline(
                 continue;
             }
 
+            // Validate CPH format for amls2_port collection
+            if (collectionName == "amls2_port")
+            {
+                var cphValue = csv.GetField("CPH");
+                if (!IsValid5DigitCph(cphValue))
+                {
+                    var primaryKeyValue = string.Join(EtlConstants.CompositeKeyDelimiter, headers.PrimaryKeyHeaderNames.Select(pkHeader => csv.GetField(pkHeader) ?? string.Empty));
+                    Debug.WriteLine($"[keepetl] Invalid CPH format '{cphValue}' (expected 5 digits) for record with primary key '{primaryKeyValue}' in file {fileKey}, skipping record");
+                    logger.LogWarning("Invalid CPH format '{CPH}' (expected 5 digits) for record with primary key '{PrimaryKey}' in file {FileKey}, skipping record",
+                        cphValue, primaryKeyValue, fileKey);
+                    fileMetrics.RecordsSkipped++;
+                    continue;
+                }
+            }
+
             var document = CreateDocumentFromCsvRecord(csv, headers, definition);
             batch.Add((document, changeType));
 
@@ -603,6 +618,17 @@ public class IngestionPipeline(
         return changeType == ChangeType.Delete ||
                changeType == ChangeType.Update ||
                changeType == ChangeType.Insert;
+    }
+
+    private static bool IsValid5DigitCph(string? cphValue)
+    {
+        if (string.IsNullOrWhiteSpace(cphValue))
+        {
+            return false;
+        }
+
+        // CPH should be exactly 5 digits
+        return cphValue.Length == 5 && cphValue.All(char.IsDigit);
     }
 
     private void LogProgressIfNeeded(int recordsProcessed, string fileKey)

--- a/tests/KeeperData.Bridge.Tests.Integration/Core/ETL/IngestionPipelineCompositeKeyTests.cs
+++ b/tests/KeeperData.Bridge.Tests.Integration/Core/ETL/IngestionPipelineCompositeKeyTests.cs
@@ -548,6 +548,12 @@ public class IngestionPipelineCompositeKeyTests : IAsyncLifetime
             SamCPHHolder = dataSetDefinition,
             SamHerd = dataSetDefinition,
             SamParty = dataSetDefinition,
+            SamTla = dataSetDefinition,
+            Amls2CommonLand = dataSetDefinition,
+            Amls2Port = dataSetDefinition,
+            CtsAgent = dataSetDefinition,
+            AmesHaulier = dataSetDefinition,
+            SamShowground = dataSetDefinition,
             All = [dataSetDefinition]
         };
 

--- a/tests/KeeperData.Bridge.Tests.Integration/Core/ETL/IngestionPipelineIntegrationTests.cs
+++ b/tests/KeeperData.Bridge.Tests.Integration/Core/ETL/IngestionPipelineIntegrationTests.cs
@@ -844,6 +844,123 @@ public class IngestionPipelineIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task StartAsync_WithInvalidCphForAmls2Port_ShouldSkipInvalidRecords()
+    {
+        // Arrange
+        var testDate = new DateOnly(2024, 12, 15);
+
+        // CSV with mix of valid and invalid CPH values for amls2_port collection
+        // Valid CPH: exactly 5 digits
+        // Invalid CPH: wrong length, contains letters, null/empty
+        var csvContent = "CPH|PortName|Location|CHANGE_TYPE\n"
+            + "12345|Valid Port 1|Location A|I\n"           // Valid: 5 digits
+            + "67890|Valid Port 2|Location B|I\n"           // Valid: 5 digits
+            + "1234|Invalid Port 3|Location C|I\n"          // Invalid: 4 digits
+            + "123456|Invalid Port 4|Location D|I\n"        // Invalid: 6 digits
+            + "12A45|Invalid Port 5|Location E|I\n"         // Invalid: contains letter
+            + "12-45|Invalid Port 6|Location F|I\n"         // Invalid: contains hyphen
+            + "|Invalid Port 7|Location G|I\n"              // Invalid: empty CPH
+            + "00000|Valid Port 3|Location H|I\n"           // Valid: 5 zeros (edge case)
+            + "ABC12|Invalid Port 8|Location I|I\n";        // Invalid: starts with letters
+
+        var fileName = $"LITP_AMLS2PORT_{testDate:yyyyMMdd}120000.csv";
+        await UploadCsvToS3($"{DestinationFolder}/{fileName}", csvContent);
+
+        var importId = Guid.NewGuid();
+
+        // Act
+        await _ingestionPipeline.StartAsync(CreateImportReport(importId), CancellationToken.None);
+
+        // Assert
+        var database = _mongoClient.GetDatabase(_testDatabaseName);
+        var collection = database.GetCollection<BsonDocument>("amls2_port");
+
+        var documents = await collection.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
+
+        // Should only have 3 valid records (12345, 67890, 00000)
+        documents.Should().HaveCount(3, "only records with exactly 5 digits should be ingested");
+
+        // Verify the valid records
+        var validCphs = documents.Select(d => d["CPH"].AsString).ToList();
+        validCphs.Should().BeEquivalentTo(new[] { "12345", "67890", "00000" },
+            "only valid 5-digit CPH values should be in the database");
+
+        // Verify first valid record
+        var port1 = documents.FirstOrDefault(d => d["CPH"] == "12345");
+        port1.Should().NotBeNull();
+        port1!["PortName"].Should().Be("Valid Port 1");
+        port1["Location"].Should().Be("Location A");
+        port1.Contains("CreatedAtUtc").Should().BeTrue();
+        port1.Contains("UpdatedAtUtc").Should().BeTrue();
+
+        // Verify edge case (all zeros)
+        var port3 = documents.FirstOrDefault(d => d["CPH"] == "00000");
+        port3.Should().NotBeNull();
+        port3!["PortName"].Should().Be("Valid Port 3");
+
+        // Verify logs contain warnings about skipped records
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Invalid CPH format") && v.ToString()!.Contains("expected 5 digits")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeast(6),
+            "should log warnings for each invalid CPH record");
+
+        _testOutputHelper.WriteLine($"Successfully ingested {documents.Count} valid records and skipped 6 invalid records");
+    }
+
+    [Fact]
+    public async Task StartAsync_WithInvalidCphForAmls2Port_ShouldNotAffectOtherCollections()
+    {
+        // Arrange
+        var testDate = new DateOnly(2024, 12, 15);
+
+        // Test that CPH validation ONLY applies to amls2_port, not other collections
+        // sam_cph_holdings should accept non-5-digit CPH values
+        var csvContent = "CPH|FarmName|Owner|Address|CHANGE_TYPE\n"
+            + "1234|Farm One|Owner A|Address 1|I\n"         // 4 digits - should be accepted for sam_cph_holdings
+            + "123456|Farm Two|Owner B|Address 2|I\n"       // 6 digits - should be accepted for sam_cph_holdings
+            + "12A45|Farm Three|Owner C|Address 3|I\n";     // Contains letter - should be accepted for sam_cph_holdings
+
+        var fileName = $"LITP_SAMCPHHOLDING_{testDate:yyyyMMdd}120000.csv";
+        await UploadCsvToS3($"{DestinationFolder}/{fileName}", csvContent);
+
+        var importId = Guid.NewGuid();
+
+        // Act
+        await _ingestionPipeline.StartAsync(CreateImportReport(importId), CancellationToken.None);
+
+        // Assert
+        var database = _mongoClient.GetDatabase(_testDatabaseName);
+        var collection = database.GetCollection<BsonDocument>("sam_cph_holdings");
+
+        var documents = await collection.Find(FilterDefinition<BsonDocument>.Empty).ToListAsync();
+
+        // All 3 records should be ingested (CPH validation only applies to amls2_port)
+        documents.Should().HaveCount(3, "sam_cph_holdings should accept any CPH format");
+
+        var cphs = documents.Select(d => d["CPH"].AsString).ToList();
+        cphs.Should().BeEquivalentTo(new[] { "1234", "123456", "12A45" },
+            "CPH validation should not apply to collections other than amls2_port");
+
+        // Verify no warnings were logged about CPH format (only applies to amls2_port)
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Invalid CPH format") && v.ToString()!.Contains("expected 5 digits")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never,
+            "should not log CPH validation warnings for collections other than amls2_port");
+
+        _testOutputHelper.WriteLine($"Successfully verified CPH validation only applies to amls2_port collection");
+    }
+
+    [Fact]
     public async Task StartAsync_WithEmptyAccumulatorFieldsOnFirstImport_ShouldCreateEmptyArrays()
     {
         // Arrange
@@ -935,7 +1052,16 @@ public class IngestionPipelineIntegrationTests : IAsyncLifetime
             SamCPHHolder = new DataSetDefinition("sam_cph_holder", "LITP_SAMCPHHOLDER_{0}", ["PARTY_ID"], ChangeType.HeaderName, []),
             SamHerd = new DataSetDefinition("sam_herd", "LITP_SAMHERD_{0}", ["CPHH", "HERDMARK", "ANIMAL_PURPOSE_CODE"], ChangeType.HeaderName, []),
             SamParty = new DataSetDefinition("sam_party", "LITP_SAMPARTY_{0}", ["PARTY_ID"], ChangeType.HeaderName, []),
-            All = [new DataSetDefinition("sam_cph_holdings", "LITP_SAMCPHHOLDING_{0}", ["CPH"], ChangeType.HeaderName, ["ADDRESS_PK", "DISEASE_TYPE", "ANIMAL_SPECIES_CODE"])]
+            SamTla = new DataSetDefinition("sam_tla", "LITP_SAMTLA_{0}", ["TEMP_CPH"], ChangeType.HeaderName, []),
+            Amls2CommonLand = new DataSetDefinition("amls2_common_land", "LITP_AMLS2COMMONLAND_{0}", ["MAIN_CPH"], ChangeType.HeaderName, []),
+            Amls2Port = new DataSetDefinition("amls2_port", "LITP_AMLS2PORT_{0}", ["CPH"], ChangeType.HeaderName, []),
+            CtsAgent = new DataSetDefinition("cts_agent", "LITP_CTSAGENT_{0}", ["PAR_ID"], ChangeType.HeaderName, []),
+            AmesHaulier = new DataSetDefinition("ames_haulier", "LITP_AMESHAULIER_{0}", ["DISPLAY_LICENCE_NUMBER"], ChangeType.HeaderName, []),
+            SamShowground = new DataSetDefinition("sam_showground", "LITP_SAMSHOWGROUND_{0}", ["CPH"], ChangeType.HeaderName, []),
+            All = [
+                new DataSetDefinition("sam_cph_holdings", "LITP_SAMCPHHOLDING_{0}", ["CPH"], ChangeType.HeaderName, ["ADDRESS_PK", "DISEASE_TYPE", "ANIMAL_SPECIES_CODE"]),
+                new DataSetDefinition("amls2_port", "LITP_AMLS2PORT_{0}", ["CPH"], ChangeType.HeaderName, [])
+            ]
         };
 
         factory.Setup(x => x.Create(It.IsAny<IBlobStorageServiceReadOnly>()))

--- a/tests/KeeperData.Bridge.Tests.Integration/Core/Querying/ODataQueryServiceIntegrationTests.cs
+++ b/tests/KeeperData.Bridge.Tests.Integration/Core/Querying/ODataQueryServiceIntegrationTests.cs
@@ -56,6 +56,12 @@ public class ODataQueryServiceIntegrationTests : IAsyncLifetime
             SamCPHHolder = new DataSetDefinition(_testCollectionName, "TEST_PRODUCTS_{0}", ["ProductId"], "CHANGETYPE", []),
             SamHerd = new DataSetDefinition(_testCollectionName, "TEST_PRODUCTS_{0}", ["ProductId"], "CHANGETYPE", []),
             SamParty = new DataSetDefinition(_testCollectionName, "TEST_PARTY_{0}", ["PartyId"], "CHANGETYPE", []),
+            SamTla = new DataSetDefinition("sam_tla", "LITP_SAMTLA_{0}", ["TEMP_CPH"], "CHANGETYPE", []),
+            Amls2CommonLand = new DataSetDefinition("amls2_common_land", "LITP_AMLS2COMMONLAND_{0}", ["MAIN_CPH"], "CHANGETYPE", []),
+            Amls2Port = new DataSetDefinition("amls2_port", "LITP_AMLS2PORT_{0}", ["CPH"], "CHANGETYPE", []),
+            CtsAgent = new DataSetDefinition("cts_agent", "LITP_CTSAGENT_{0}", ["PAR_ID"], "CHANGETYPE", []),
+            AmesHaulier = new DataSetDefinition("ames_haulier", "LITP_AMESHAULIER_{0}", ["DISPLAY_LICENCE_NUMBER"], "CHANGETYPE", []),
+            SamShowground = new DataSetDefinition("sam_showground", "LITP_SAMSHOWGROUND_{0}", ["CPH"], "CHANGETYPE", []),
             All =
             [
                 new DataSetDefinition("sam_cph_holdings", "LITP_SAMCPHHOLDING_{0}", ["CPH"], "CHANGETYPE", []),

--- a/tests/KeeperData.Bridge.Tests.Integration/Scenarios/EndToEndImportScenarioTests.cs
+++ b/tests/KeeperData.Bridge.Tests.Integration/Scenarios/EndToEndImportScenarioTests.cs
@@ -782,6 +782,12 @@ public class EndToEndImportScenarioTests : IAsyncLifetime
             SamCPHHolder = dataSetDefinition,
             SamHerd = dataSetDefinition,
             SamParty = dataSetDefinition,
+            SamTla = dataSetDefinition,
+            Amls2CommonLand = dataSetDefinition,
+            Amls2Port = dataSetDefinition,
+            CtsAgent = dataSetDefinition,
+            AmesHaulier = dataSetDefinition,
+            SamShowground = dataSetDefinition,
             All = [dataSetDefinition]
         };
 

--- a/tests/KeeperData.Core.Tests.Unit/CleanseReporting/Cleanse/Analysis/Command/CleanseAnalysisProgressReportingTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/CleanseReporting/Cleanse/Analysis/Command/CleanseAnalysisProgressReportingTests.cs
@@ -275,7 +275,13 @@ public sealed class CleanseAnalysisProgressReportingTests
             SamCPHHolding = Def("sam_cph_holding"),
             SamHerd = Def("sam_herd"),
             SamParty = Def("sam_party"),
-            SamCPHHolder = Def("sam_cph_holder")
+            SamCPHHolder = Def("sam_cph_holder"),
+            SamTla = Def("sam_tla"),
+            Amls2CommonLand = Def("amls2_common_land"),
+            Amls2Port = Def("amls2_port"),
+            CtsAgent = Def("cts_agent"),
+            AmesHaulier = Def("ames_haulier"),
+            SamShowground = Def("sam_showground")
         };
     }
 


### PR DESCRIPTION
Introduce CPH format validation for amls2_port collection, skipping and logging records with invalid CPH values. Add IsValid5DigitCph helper. Expand integration tests to verify validation logic and ensure it does not affect other collections. Update DataSetDefinitions and test setups to include new collections: SamTla, Amls2CommonLand, Amls2Port, CtsAgent, AmesHaulier, and SamShowground.