### PR TITLE
IExternalCatalogueServiceFactory.Create .. must return an interface

### DIFF
--- a/src/KeeperData.Bridge/Controllers/ExternalCatalogueController.cs
+++ b/src/KeeperData.Bridge/Controllers/ExternalCatalogueController.cs
@@ -47,7 +47,7 @@ public class ExternalCatalogueController(
 
         var fileSets = await ExternalCatalogueService.GetFileSetsAsync(days, cancellationToken);
 
-        var report = GenerateReport(sourceType, fileSets, ExternalCatalogueService.ToString());
+        var report = GenerateReport(sourceType, fileSets, ExternalCatalogueService.GetType().Name);
 
         return Content(report, "text/plain", Encoding.UTF8);
     }

--- a/src/KeeperData.Core/ETL/Abstract/IExternalCatalogueServiceFactory.cs
+++ b/src/KeeperData.Core/ETL/Abstract/IExternalCatalogueServiceFactory.cs
@@ -5,6 +5,6 @@ namespace KeeperData.Core.ETL.Abstract;
 
 public interface IExternalCatalogueServiceFactory
 {
-    ExternalCatalogueService Create(IBlobStorageServiceReadOnly blobStorage);
-    ExternalCatalogueService Create(string sourceType);
+    IExternalCatalogueService Create(IBlobStorageServiceReadOnly blobStorage);
+    IExternalCatalogueService Create(string sourceType);
 }

--- a/src/KeeperData.Core/ETL/Impl/AcquisitionPipeline.cs
+++ b/src/KeeperData.Core/ETL/Impl/AcquisitionPipeline.cs
@@ -119,7 +119,7 @@ public class AcquisitionPipeline(
         }
     }
 
-    private (IBlobStorageServiceReadOnly SourceBlobs, ExternalCatalogueService ExternalCatalogueService, IBlobStorageService DestinationBlobs)
+    private (IBlobStorageServiceReadOnly SourceBlobs, IExternalCatalogueService ExternalCatalogueService, IBlobStorageService DestinationBlobs)
         InitializeStorageServices(Guid importId, string sourceType)
     {
         var sourceBlobs = blobStorageServiceFactory.GetSource(sourceType);

--- a/src/KeeperData.Core/ETL/Impl/ExternalCatalogueServiceFactory.cs
+++ b/src/KeeperData.Core/ETL/Impl/ExternalCatalogueServiceFactory.cs
@@ -7,6 +7,6 @@ namespace KeeperData.Core.ETL.Impl;
 [ExcludeFromCodeCoverage(Justification = "Simple factory wrapper - covered by integration tests.")]
 public class ExternalCatalogueServiceFactory(TimeProvider timeProvider, IDataSetDefinitions dataSetDefinitions, IBlobStorageServiceFactory factory) : IExternalCatalogueServiceFactory
 {
-    public ExternalCatalogueService Create(string sourceType) => new(factory.GetSource(sourceType), timeProvider, dataSetDefinitions);
-    public ExternalCatalogueService Create(IBlobStorageServiceReadOnly blobStorage) => new(blobStorage, timeProvider, dataSetDefinitions);
+    public IExternalCatalogueService Create(string sourceType) => new ExternalCatalogueService(factory.GetSource(sourceType), timeProvider, dataSetDefinitions);
+    public IExternalCatalogueService Create(IBlobStorageServiceReadOnly blobStorage) => new ExternalCatalogueService(blobStorage, timeProvider, dataSetDefinitions);
 }

--- a/src/KeeperData.Core/ETL/Impl/IngestionPipeline.cs
+++ b/src/KeeperData.Core/ETL/Impl/IngestionPipeline.cs
@@ -108,7 +108,7 @@ public class IngestionPipeline(
         }
     }
 
-    private (IBlobStorageService BlobStorage, ExternalCatalogueService CatalogueService) InitializeStorageServices(Guid importId)
+    private (IBlobStorageService BlobStorage, IExternalCatalogueService CatalogueService) InitializeStorageServices(Guid importId)
     {
         Debug.WriteLine($"[keepetl] Initializing blob storage services for ImportId: {importId}");
         var blobs = blobStorageServiceFactory.Get();
@@ -119,7 +119,7 @@ public class IngestionPipeline(
         return (blobs, catalogueService);
     }
 
-    private async Task<(ImmutableList<FileSet> FileSets, int TotalFiles)> DiscoverFilesAsync(Guid importId, ExternalCatalogueService catalogueService, CancellationToken ct)
+    private async Task<(ImmutableList<FileSet> FileSets, int TotalFiles)> DiscoverFilesAsync(Guid importId, IExternalCatalogueService catalogueService, CancellationToken ct)
     {
         Debug.WriteLine($"[keepetl] Step 1: Discovering files for ImportId: {importId}");
         logger.LogInformation("Step 1: Discovering files for ImportId: {ImportId}", importId);

--- a/tests/KeeperData.Bridge.Tests.Integration/Core/ETL/ExternalCatalogueServiceIntegrationTests.cs
+++ b/tests/KeeperData.Bridge.Tests.Integration/Core/ETL/ExternalCatalogueServiceIntegrationTests.cs
@@ -22,7 +22,7 @@ public class ExternalCatalogueServiceIntegrationTests : IAsyncLifetime
     private readonly Mock<ILogger<S3BlobStorageServiceReadOnly>> _loggerMock;
     private readonly S3BlobStorageServiceReadOnly _blobService;
     private readonly TestDataSetDefinitions _testDataSetDefinitions;
-    private readonly ExternalCatalogueService _ExternalCatalogueService;
+    private readonly IExternalCatalogueService _ExternalCatalogueService;
     private readonly FakeTimeProvider _timeProvider;
     private readonly List<string> _createdTestFileKeys = new();
 


### PR DESCRIPTION
Came across a factory interface, that returns a concrete class, when it really should return an abstraction, so that it's testable. This blocked me from testing stage 1 via unit tests ... until now, we've simply excluded test coverage for discovery, to avoid this issue but I'd like to address that and fix it properly, for the new pipeline work.

So in short, I simply changed return type:   
`ExternalCatalogueService -> IExternalCatalogueService`

....and fixed all issues that arise as result. 