### PR TITLE
Feature/LKPR-68 rename services to legacy in anticipation of new services, split files out, etc

### DIFF
--- a/src/KeeperData.Bridge/Controllers/ExternalCatalogueController.cs
+++ b/src/KeeperData.Bridge/Controllers/ExternalCatalogueController.cs
@@ -43,7 +43,7 @@ public class ExternalCatalogueController(
             return BadRequest($"Invalid source type. Must be '{BlobStorageSources.Internal}' or '{BlobStorageSources.External}'.");
         }
 
-        var ExternalCatalogueService = ExternalCatalogueServiceFactory.Create(sourceType);
+        var ExternalCatalogueService = ExternalCatalogueServiceFactory.CreateLegacy(sourceType);
 
         var fileSets = await ExternalCatalogueService.GetFileSetsAsync(days, cancellationToken);
 

--- a/src/KeeperData.Core/ETL/Abstract/IExternalCatalogueServiceFactory.cs
+++ b/src/KeeperData.Core/ETL/Abstract/IExternalCatalogueServiceFactory.cs
@@ -5,6 +5,6 @@ namespace KeeperData.Core.ETL.Abstract;
 
 public interface IExternalCatalogueServiceFactory
 {
-    IExternalCatalogueService Create(IBlobStorageServiceReadOnly blobStorage);
-    IExternalCatalogueService Create(string sourceType);
+    IExternalCatalogueService CreateLegacy(IBlobStorageServiceReadOnly blobStorage);
+    IExternalCatalogueService CreateLegacy(string sourceType);
 }

--- a/src/KeeperData.Core/ETL/Impl/AcquisitionPipeline.cs
+++ b/src/KeeperData.Core/ETL/Impl/AcquisitionPipeline.cs
@@ -123,7 +123,7 @@ public class AcquisitionPipeline(
         InitializeStorageServices(Guid importId, string sourceType)
     {
         var sourceBlobs = blobStorageServiceFactory.GetSource(sourceType);
-        var catalogueService = ExternalCatalogueServiceFactory.Create(sourceBlobs);
+        var catalogueService = ExternalCatalogueServiceFactory.CreateLegacy(sourceBlobs);
         var destinationBlobs = blobStorageServiceFactory.Get();
 
         logger.LogDebug("Initialized blob storage services for ImportId: {ImportId}", importId);

--- a/src/KeeperData.Core/ETL/Impl/EtlFile.cs
+++ b/src/KeeperData.Core/ETL/Impl/EtlFile.cs
@@ -1,0 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
+using KeeperData.Core.Storage.Dtos;
+
+namespace KeeperData.Core.ETL.Impl;
+
+/// <summary>A discovered source file and the timestamp encoded in its name.</summary>
+[ExcludeFromCodeCoverage(Justification = "Simple data transfer record.")]
+public record EtlFile(StorageObjectInfo StorageObject, DateTimeOffset Timestamp);

--- a/src/KeeperData.Core/ETL/Impl/ExternalCatalogueServiceFactory.cs
+++ b/src/KeeperData.Core/ETL/Impl/ExternalCatalogueServiceFactory.cs
@@ -7,6 +7,6 @@ namespace KeeperData.Core.ETL.Impl;
 [ExcludeFromCodeCoverage(Justification = "Simple factory wrapper - covered by integration tests.")]
 public class ExternalCatalogueServiceFactory(TimeProvider timeProvider, IDataSetDefinitions dataSetDefinitions, IBlobStorageServiceFactory factory) : IExternalCatalogueServiceFactory
 {
-    public IExternalCatalogueService Create(string sourceType) => new ExternalCatalogueService(factory.GetSource(sourceType), timeProvider, dataSetDefinitions);
-    public IExternalCatalogueService Create(IBlobStorageServiceReadOnly blobStorage) => new ExternalCatalogueService(blobStorage, timeProvider, dataSetDefinitions);
+    public IExternalCatalogueService CreateLegacy(string sourceType) => new LegacyExternalCatalogueService(factory.GetSource(sourceType), timeProvider, dataSetDefinitions);
+    public IExternalCatalogueService CreateLegacy(IBlobStorageServiceReadOnly blobStorage) => new LegacyExternalCatalogueService(blobStorage, timeProvider, dataSetDefinitions);
 }

--- a/src/KeeperData.Core/ETL/Impl/FileSet.cs
+++ b/src/KeeperData.Core/ETL/Impl/FileSet.cs
@@ -1,0 +1,7 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace KeeperData.Core.ETL.Impl;
+
+/// <summary>The files discovered for a single dataset definition.</summary>
+[ExcludeFromCodeCoverage(Justification = "Simple data transfer record.")]
+public record FileSet(DataSetDefinition Definition, EtlFile[] Files);

--- a/src/KeeperData.Core/ETL/Impl/IngestionPipeline.cs
+++ b/src/KeeperData.Core/ETL/Impl/IngestionPipeline.cs
@@ -112,7 +112,7 @@ public class IngestionPipeline(
     {
         Debug.WriteLine($"[keepetl] Initializing blob storage services for ImportId: {importId}");
         var blobs = blobStorageServiceFactory.Get();
-        var catalogueService = ExternalCatalogueServiceFactory.Create(blobs);
+        var catalogueService = ExternalCatalogueServiceFactory.CreateLegacy(blobs);
 
         logger.LogDebug("Initialized blob storage services for ImportId: {ImportId}", importId);
 

--- a/src/KeeperData.Core/ETL/Impl/LegacyExternalCatalogueService.cs
+++ b/src/KeeperData.Core/ETL/Impl/LegacyExternalCatalogueService.cs
@@ -3,18 +3,16 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using KeeperData.Core.ETL.Abstract;
 using KeeperData.Core.Storage;
-using KeeperData.Core.Storage.Dtos;
 
 namespace KeeperData.Core.ETL.Impl;
 
-[ExcludeFromCodeCoverage(Justification = "Simple data transfer record.")]
-public record EtlFile(StorageObjectInfo StorageObject, DateTimeOffset Timestamp);
-
-[ExcludeFromCodeCoverage(Justification = "Simple data transfer record.")]
-public record FileSet(DataSetDefinition Definition, EtlFile[] Files);
-
+/// <summary>
+/// The original per-day-scan catalogue (slow): it walks every date in the requested range and issues one
+/// storage listing per date per dataset, so the number of round-trips grows with the lookback
+/// window (a 250 day lookback across 13 datasets is ~3,250 listings).
+/// </summary>
 [ExcludeFromCodeCoverage(Justification = "External catalogue service with S3 dependencies - covered by integration tests.")]
-public class ExternalCatalogueService(IBlobStorageServiceReadOnly sourceBlobs,
+public class LegacyExternalCatalogueService(IBlobStorageServiceReadOnly sourceBlobs,
     TimeProvider timeProvider,
     IDataSetDefinitions dataSetDefinitions) : IExternalCatalogueService
 {
@@ -144,7 +142,7 @@ public class ExternalCatalogueService(IBlobStorageServiceReadOnly sourceBlobs,
                 System.Globalization.DateTimeStyles.None,
                 out var parsedDateTime))
             {
-                // Create DateTimeOffset from the parsed DateTime, explicitly specifying UTC offset
+                // CreateLegacy DateTimeOffset from the parsed DateTime, explicitly specifying UTC offset
                 var utcDateTime = DateTime.SpecifyKind(parsedDateTime, DateTimeKind.Utc);
                 return new DateTimeOffset(utcDateTime, TimeSpan.Zero);
             }
@@ -179,5 +177,5 @@ public class ExternalCatalogueService(IBlobStorageServiceReadOnly sourceBlobs,
         return string.Format(definition.FilePrefixFormat, formattedDate);
     }
 
-    public override string ToString() => $"{nameof(ExternalCatalogueService)}[{sourceBlobs}]";
+    public override string ToString() => $"{nameof(LegacyExternalCatalogueService)}[{sourceBlobs}]";
 }

--- a/src/KeeperData.Core/EtlPipeline/Stages/S3RawFolderSource.cs
+++ b/src/KeeperData.Core/EtlPipeline/Stages/S3RawFolderSource.cs
@@ -16,7 +16,7 @@ public sealed class S3RawFolderSource(IExternalCatalogueServiceFactory catalogue
     {
         var etlContext = (EtlPipelineContext)context;
 
-        var catalogue = catalogueFactory.Create(etlContext.SourceType);
+        var catalogue = catalogueFactory.CreateLegacy(etlContext.SourceType);
         var fileSets = await catalogue.GetFileSetsAsync(etlContext.LookbackDays, cancellationToken);
 
         foreach (var fileSet in fileSets)

--- a/tests/KeeperData.Bridge.Tests.Integration/Core/ETL/ExternalCatalogueServiceIntegrationTests.cs
+++ b/tests/KeeperData.Bridge.Tests.Integration/Core/ETL/ExternalCatalogueServiceIntegrationTests.cs
@@ -11,7 +11,7 @@ using Xunit.Abstractions;
 namespace KeeperData.Bridge.Tests.Integration.Core.ETL;
 
 /// <summary>
-/// Integration tests for ExternalCatalogueService using TestContainers.LocalStack.
+/// Integration tests for LegacyExternalCatalogueService using TestContainers.LocalStack.
 /// Tests the ability to discover files within S3 based on date ranges and dataset definitions.
 /// </summary>
 [Collection("LocalStack"), Trait("Dependence", "docker")]
@@ -48,7 +48,7 @@ public class ExternalCatalogueServiceIntegrationTests : IAsyncLifetime
         _timeProvider = new FakeTimeProvider(new DateTimeOffset(2024, 12, 15, 10, 0, 0, TimeSpan.Zero));
 
         // Create the service under test
-        _ExternalCatalogueService = new ExternalCatalogueService(_blobService, _timeProvider, _testDataSetDefinitions);
+        _ExternalCatalogueService = new LegacyExternalCatalogueService(_blobService, _timeProvider, _testDataSetDefinitions);
     }
 
     public async Task InitializeAsync()

--- a/tests/KeeperData.Bridge.Tests.Integration/Core/ETL/IngestionPipelineCompositeKeyTests.cs
+++ b/tests/KeeperData.Bridge.Tests.Integration/Core/ETL/IngestionPipelineCompositeKeyTests.cs
@@ -557,9 +557,9 @@ public class IngestionPipelineCompositeKeyTests : IAsyncLifetime
             All = [dataSetDefinition]
         };
 
-        var catalogueService = new ExternalCatalogueService(destBlobService, timeProvider, definitions);
+        var catalogueService = new LegacyExternalCatalogueService(destBlobService, timeProvider, definitions);
         var catalogueFactory = new Mock<IExternalCatalogueServiceFactory>();
-        catalogueFactory.Setup(x => x.Create(It.IsAny<IBlobStorageServiceReadOnly>())).Returns(catalogueService);
+        catalogueFactory.Setup(x => x.CreateLegacy(It.IsAny<IBlobStorageServiceReadOnly>())).Returns(catalogueService);
 
         var mongoConfig = Options.Create<IDatabaseConfig>(new MongoConfig
         {
@@ -651,7 +651,7 @@ public class IngestionPipelineCompositeKeyTests : IAsyncLifetime
         var factory = new Mock<IExternalCatalogueServiceFactory>();
         var definitions = StandardDataSetDefinitionsBuilder.Build();
 
-        factory.Setup(x => x.Create(It.IsAny<IBlobStorageServiceReadOnly>()))
+        factory.Setup(x => x.CreateLegacy(It.IsAny<IBlobStorageServiceReadOnly>()))
                  .Returns((IBlobStorageServiceReadOnly blobs) =>
              {
                  var loggerMock = new Mock<ILogger<S3BlobStorageServiceReadOnly>>();
@@ -662,7 +662,7 @@ public class IngestionPipelineCompositeKeyTests : IAsyncLifetime
                      DestinationFolder);
 
                  var timeProvider = new FakeTimeProvider(new DateTimeOffset(2024, 12, 15, 10, 0, 0, TimeSpan.Zero));
-                 return new ExternalCatalogueService(destBlobService, timeProvider, definitions);
+                 return new LegacyExternalCatalogueService(destBlobService, timeProvider, definitions);
              });
 
         return factory.Object;

--- a/tests/KeeperData.Bridge.Tests.Integration/Core/ETL/IngestionPipelineIntegrationTests.cs
+++ b/tests/KeeperData.Bridge.Tests.Integration/Core/ETL/IngestionPipelineIntegrationTests.cs
@@ -1064,7 +1064,7 @@ public class IngestionPipelineIntegrationTests : IAsyncLifetime
             ]
         };
 
-        factory.Setup(x => x.Create(It.IsAny<IBlobStorageServiceReadOnly>()))
+        factory.Setup(x => x.CreateLegacy(It.IsAny<IBlobStorageServiceReadOnly>()))
             .Returns((IBlobStorageServiceReadOnly blobs) =>
             {
                 // Create a blob service that points to the destination folder where test files are uploaded
@@ -1076,7 +1076,7 @@ public class IngestionPipelineIntegrationTests : IAsyncLifetime
                     DestinationFolder);
 
                 var timeProvider = new FakeTimeProvider(new DateTimeOffset(2024, 12, 15, 10, 0, 0, TimeSpan.Zero));
-                return new ExternalCatalogueService(destBlobService, timeProvider, testDefinitions);
+                return new LegacyExternalCatalogueService(destBlobService, timeProvider, testDefinitions);
             });
 
         return factory.Object;

--- a/tests/KeeperData.Core.Tests.Unit/EtlPipeline/S3RawFolderSourceTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/EtlPipeline/S3RawFolderSourceTests.cs
@@ -17,7 +17,7 @@ public class S3RawFolderSourceTests
 
     private S3RawFolderSource Sut()
     {
-        _catalogueFactory.Setup(f => f.Create(It.IsAny<string>())).Returns(_catalogue.Object);
+        _catalogueFactory.Setup(f => f.CreateLegacy(It.IsAny<string>())).Returns(_catalogue.Object);
         return new S3RawFolderSource(_catalogueFactory.Object);
     }
 
@@ -49,7 +49,7 @@ public class S3RawFolderSourceTests
 
         await StageRunner.RunSourceAsync(Sut(), StageRunner.Context(sourceType: "internal"));
 
-        _catalogueFactory.Verify(f => f.Create("internal"), Times.Once);
+        _catalogueFactory.Verify(f => f.CreateLegacy("internal"), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
Just prep work for Feature/LKPR-68 to simplify the next one:
Renames services to "legacy" and split entities into separate classes. 
No functional changes , purely structural cleanup for the bigger PR coming next.