### PR TITLE
Add idempotent snapshotting to ETL pipeline

### DIFF
--- a/src/KeeperData.Core/EtlConstants.cs
+++ b/src/KeeperData.Core/EtlConstants.cs
@@ -12,4 +12,7 @@ public static class EtlConstants
     // S3 automatically prefixes user metadata with "x-amz-meta-" and lowercases the keys
     public const string MetadataKeySourceEncryptedLength = "x-amz-meta-sourceencryptedlength";
     public const string MetadataKeySourceETag = "x-amz-meta-sourceetag";
+
+    /// <summary>The normalised file key a snapshot was produced from.</summary>
+    public const string MetadataKeySnapshotSourceKey = "x-amz-meta-snapshotsourcekey";
 }

--- a/src/KeeperData.Core/EtlPipeline/EtlPipelineFactory.cs
+++ b/src/KeeperData.Core/EtlPipeline/EtlPipelineFactory.cs
@@ -1,13 +1,19 @@
 using KeeperData.Core.ETL.Abstract;
 using KeeperData.Core.EtlPipeline.Fluent;
 using KeeperData.Core.EtlPipeline.Stages;
+using KeeperData.Core.EtlPipeline.Storage;
 using KeeperData.Core.Pipeline;
+using Microsoft.Extensions.Logging;
 
 namespace KeeperData.Core.EtlPipeline;
 
 /// <summary>Defines the ETL pipeline. The single place the stage order lives.
 /// Implementing a stage does not require changing this file (only adding a dependency does).</summary>
-public sealed class EtlPipelineFactory(IExternalCatalogueServiceFactory catalogueFactory) : IEtlPipelineFactory
+public sealed class EtlPipelineFactory(
+    IExternalCatalogueServiceFactory catalogueFactory,
+    IEtlPipelineStorageProvider storageProvider,
+    TimeProvider timeProvider,
+    ILogger<SnapshotStage> snapshotLogger) : IEtlPipelineFactory
 {
     public PipelineDefinition Create()
         => PipelineBuilder
@@ -15,7 +21,7 @@ public sealed class EtlPipelineFactory(IExternalCatalogueServiceFactory catalogu
             .Discover()      // -> DiscoveredFileSet
             .Decrypt()       // -> RawFileSet        (raw/)
             .Normalise()     // -> NormalisedFileSet (normalised/*.parquet)
-            .Snapshot()      // -> SnapshotFile      (snapshots/*.parquet)
+            .Snapshot(storageProvider, timeProvider, snapshotLogger) // -> SnapshotFile (snapshots/*.parquet)
             .LoadDuckDb()    // -> StagingDatabase   (staging/*.duckdb)
             .Build();
 }

--- a/src/KeeperData.Core/EtlPipeline/Fluent/PipelineExtensions.cs
+++ b/src/KeeperData.Core/EtlPipeline/Fluent/PipelineExtensions.cs
@@ -1,6 +1,8 @@
 using KeeperData.Core.EtlPipeline.Payloads;
 using KeeperData.Core.EtlPipeline.Stages;
+using KeeperData.Core.EtlPipeline.Storage;
 using KeeperData.Core.Pipeline;
+using Microsoft.Extensions.Logging;
 
 namespace KeeperData.Core.EtlPipeline.Fluent;
 
@@ -17,8 +19,12 @@ public static class PipelineExtensions
     public static PipelineBuilder<NormalisedFileSet> Normalise(this PipelineBuilder<RawFileSet> builder)
         => builder.Then(new NormaliseStage());
 
-    public static PipelineBuilder<SnapshotFile> Snapshot(this PipelineBuilder<NormalisedFileSet> builder)
-        => builder.Then(new SnapshotStage());
+    public static PipelineBuilder<SnapshotFile> Snapshot(
+        this PipelineBuilder<NormalisedFileSet> builder,
+        IEtlPipelineStorageProvider storageProvider,
+        TimeProvider timeProvider,
+        ILogger<SnapshotStage> logger)
+        => builder.Then(new SnapshotStage(storageProvider, timeProvider, logger));
 
     public static PipelineBuilder<StagingDatabase> LoadDuckDb(this PipelineBuilder<SnapshotFile> builder)
         => builder.Then(new LoadDuckDbStage());

--- a/src/KeeperData.Core/EtlPipeline/Payloads/SnapshotFile.cs
+++ b/src/KeeperData.Core/EtlPipeline/Payloads/SnapshotFile.cs
@@ -7,10 +7,11 @@ public sealed record SnapshotFile(DataSetDefinition Definition)
 {
     public Guid RunId { get; init; }
 
-    /* Delete this region once the previous stage provides these */
-    #region TEMP - PlaceholderInputs
+    public string Key { get; init; } = string.Empty;
 
-    public IReadOnlyList<string> Files { get; init; } = [];
+    public string SourceKey { get; init; } = string.Empty;
 
-    #endregion
+    public DateTimeOffset Timestamp { get; init; }
+
+    public bool Created { get; init; }
 }

--- a/src/KeeperData.Core/EtlPipeline/Stages/SnapshotStage.cs
+++ b/src/KeeperData.Core/EtlPipeline/Stages/SnapshotStage.cs
@@ -1,15 +1,171 @@
+using System.Runtime.CompilerServices;
+using KeeperData.Core.ETL.Impl;
 using KeeperData.Core.EtlPipeline.Payloads;
+using KeeperData.Core.EtlPipeline.Storage;
 using KeeperData.Core.Pipeline;
+using KeeperData.Core.Storage;
+using Microsoft.Extensions.Logging;
 
 namespace KeeperData.Core.EtlPipeline.Stages;
 
-/// <summary>Folds a dataset's deltas onto its main file (upsert on primary keys, apply CHANGE_TYPE)
-/// into one snapshot Parquet. Materialises: snapshots/.
-/// STUB - passes through. The owner implements the fold in MapAsync.</summary>
-public sealed class SnapshotStage : MapStage<NormalisedFileSet, SnapshotFile>
+/// <summary>Produces one canonical Parquet file per dataset in snapshots/, named with the dataset's
+/// clean name and a fresh ETL timestamp. Materialises: snapshots/.
+///
+/// Snapshot mode only: the latest normalised file for the dataset (by the timestamp in its name) is
+/// copied as-is. Delta walking, primary-key matching and CHANGE_TYPE handling are deferred to LKPR-34.
+///
+/// Idempotent: a snapshot records the normalised key it came from, so a re-run with no new normalised
+/// file reuses the existing snapshot instead of writing a duplicate. Existing snapshots are never
+/// overwritten and never deleted.</summary>
+public sealed class SnapshotStage(
+    IEtlPipelineStorageProvider storageProvider,
+    TimeProvider timeProvider,
+    ILogger<SnapshotStage> logger) : IStage<NormalisedFileSet, SnapshotFile>
 {
-    public override string Name => "snapshot";
+    public string Name => "snapshot";
 
-    protected override Task<SnapshotFile> MapAsync(NormalisedFileSet input, IPipelineContext context, CancellationToken cancellationToken)
-        => Task.FromResult(new SnapshotFile(input.Definition));
+    public async IAsyncEnumerable<SnapshotFile> RunAsync(
+        IAsyncEnumerable<NormalisedFileSet> input,
+        IPipelineContext context,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var normalised = storageProvider.ForFolder(EtlPipelineFolders.Normalised);
+        var snapshots = storageProvider.ForFolder(EtlPipelineFolders.Snapshots);
+
+        await foreach (var fileSet in input.WithCancellation(cancellationToken))
+        {
+            var snapshot = await SnapshotAsync(fileSet, normalised, snapshots, cancellationToken);
+
+            if (snapshot is not null)
+            {
+                yield return snapshot;
+            }
+        }
+    }
+
+    private async Task<SnapshotFile?> SnapshotAsync(
+        NormalisedFileSet fileSet,
+        IBlobStorageService normalised,
+        IBlobStorageService snapshots,
+        CancellationToken cancellationToken)
+    {
+        var definition = fileSet.Definition;
+
+        var sourceKey = SnapshotFileNaming.LatestByTimestamp(definition, await NormalisedKeysAsync(fileSet, normalised, cancellationToken));
+
+        if (sourceKey is null)
+        {
+            logger.LogInformation("No normalised file for dataset {DataSet}; no snapshot produced", definition.Name);
+            return null;
+        }
+
+        var existing = await FindSnapshotForAsync(definition, sourceKey, snapshots, cancellationToken);
+
+        if (existing is not null)
+        {
+            logger.LogInformation(
+                "Snapshot {SnapshotKey} already covers normalised file {SourceKey} for dataset {DataSet}; reusing it",
+                existing, sourceKey, definition.Name);
+
+            if (!SnapshotFileNaming.TryExtractTimestamp(definition, existing, out var existingTimestamp))
+            {
+                logger.LogWarning(
+                    "Could not parse timestamp from existing snapshot key {SnapshotKey} for dataset {DataSet}; Timestamp will be default",
+                    existing, definition.Name);
+            }
+
+            return new SnapshotFile(definition)
+            {
+                RunId = fileSet.RunId,
+                Key = existing,
+                SourceKey = sourceKey,
+                Timestamp = existingTimestamp,
+                Created = false
+            };
+        }
+
+        var timestamp = timeProvider.GetUtcNow();
+        var snapshotKey = SnapshotFileNaming.SnapshotKey(definition, timestamp);
+
+        if (await snapshots.ExistsAsync(snapshotKey, cancellationToken))
+        {
+            logger.LogWarning(
+                "Snapshot {SnapshotKey} for dataset {DataSet} already exists and will not be overwritten",
+                snapshotKey, definition.Name);
+
+            return null;
+        }
+
+        await CopyAsync(normalised, sourceKey, snapshots, snapshotKey, cancellationToken);
+
+        logger.LogInformation(
+            "Wrote snapshot {SnapshotKey} for dataset {DataSet} from normalised file {SourceKey}",
+            snapshotKey, definition.Name, sourceKey);
+
+        return new SnapshotFile(definition)
+        {
+            RunId = fileSet.RunId,
+            Key = snapshotKey,
+            SourceKey = sourceKey,
+            Timestamp = timestamp,
+            Created = true
+        };
+    }
+
+    /// <summary>The normalised keys the payload carries, falling back to listing the dataset's folder
+    /// while the normalise stage does not yet populate them.</summary>
+    private static async Task<IReadOnlyList<string>> NormalisedKeysAsync(
+        NormalisedFileSet fileSet,
+        IBlobStorageService normalised,
+        CancellationToken cancellationToken)
+    {
+        if (fileSet.Files.Count > 0)
+        {
+            return fileSet.Files;
+        }
+
+        var objects = await normalised.ListAsync(SnapshotFileNaming.DataSetPrefix(fileSet.Definition), cancellationToken);
+
+        return [.. objects.Select(o => o.Key)];
+    }
+
+    /// <summary>The newest existing snapshot for the dataset, when it was produced from
+    /// <paramref name="sourceKey"/>. Null when there is no snapshot yet or it is out of date.</summary>
+    private static async Task<string?> FindSnapshotForAsync(
+        DataSetDefinition definition,
+        string sourceKey,
+        IBlobStorageService snapshots,
+        CancellationToken cancellationToken)
+    {
+        var existing = await snapshots.ListAsync(SnapshotFileNaming.DataSetPrefix(definition), cancellationToken);
+        var latest = SnapshotFileNaming.LatestByTimestamp(definition, existing.Select(o => o.Key));
+
+        if (latest is null)
+        {
+            return null;
+        }
+
+        var metadata = await snapshots.GetMetadataAsync(latest, cancellationToken);
+
+        return metadata.UserMetadata.TryGetValue(EtlConstants.MetadataKeySnapshotSourceKey, out var recorded)
+            && string.Equals(recorded, sourceKey, StringComparison.Ordinal)
+                ? latest
+                : null;
+    }
+
+    private static async Task CopyAsync(
+        IBlobStorageService normalised,
+        string sourceKey,
+        IBlobStorageService snapshots,
+        string snapshotKey,
+        CancellationToken cancellationToken)
+    {
+        var metadata = new Dictionary<string, string> { { EtlConstants.MetadataKeySnapshotSourceKey, sourceKey } };
+
+        await using var source = await normalised.OpenReadAsync(sourceKey, cancellationToken);
+        await using var destination = await snapshots.OpenWriteAsync(
+            snapshotKey, SnapshotFileNaming.ParquetContentType, metadata, cancellationToken: cancellationToken);
+
+        await source.CopyToAsync(destination, cancellationToken);
+    }
 }

--- a/src/KeeperData.Core/EtlPipeline/Storage/SnapshotFileNaming.cs
+++ b/src/KeeperData.Core/EtlPipeline/Storage/SnapshotFileNaming.cs
@@ -1,0 +1,82 @@
+using KeeperData.Core.ETL.Impl;
+
+namespace KeeperData.Core.EtlPipeline.Storage;
+
+/// <summary>
+/// Naming convention for the files a dataset owns inside the <see cref="EtlPipelineFolders.Normalised"/>
+/// and <see cref="EtlPipelineFolders.Snapshots"/> folders. Keys are relative to those folders, because
+/// <see cref="IEtlPipelineStorageProvider.ForFolder"/> hands out storage already rooted at one of them.
+/// </summary>
+public static class SnapshotFileNaming
+{
+    public const string ParquetExtension = ".parquet";
+
+    public const string ParquetContentType = "application/vnd.apache.parquet";
+
+    /// <summary>The prefix holding every file for a dataset, e.g. <c>sam_cph_holdings/</c>.</summary>
+    public static string DataSetPrefix(DataSetDefinition definition)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        return $"{definition.Name}/";
+    }
+
+    /// <summary>The key of a dataset's snapshot for a given ETL timestamp,
+    /// e.g. <c>sam_cph_holdings/sam_cph_holdings_20260728112233.parquet</c>.</summary>
+    public static string SnapshotKey(DataSetDefinition definition, DateTimeOffset timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        var stamp = timestamp.UtcDateTime.ToString(definition.DateTimePattern);
+
+        return $"{DataSetPrefix(definition)}{definition.Name}_{stamp}{ParquetExtension}";
+    }
+
+    /// <summary>
+    /// The newest key by the timestamp encoded in its name, ties broken by ordinal key order.
+    /// Keys whose timestamp cannot be parsed are ignored. Returns null when nothing is usable.
+    /// </summary>
+    public static string? LatestByTimestamp(DataSetDefinition definition, IEnumerable<string> keys)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(keys);
+
+        string? latestKey = null;
+        var latestTimestamp = DateTimeOffset.MinValue;
+
+        foreach (var key in keys)
+        {
+            if (!TryExtractTimestamp(definition, key, out var timestamp))
+            {
+                continue;
+            }
+
+            if (latestKey is null
+                || timestamp > latestTimestamp
+                || (timestamp == latestTimestamp && string.CompareOrdinal(key, latestKey) > 0))
+            {
+                latestKey = key;
+                latestTimestamp = timestamp;
+            }
+        }
+
+        return latestKey;
+    }
+
+    /// <summary>Non-throwing form of <see cref="DataSetFileNaming.ExtractTimestamp"/>.</summary>
+    public static bool TryExtractTimestamp(DataSetDefinition definition, string key, out DateTimeOffset timestamp)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        try
+        {
+            timestamp = DataSetFileNaming.ExtractTimestamp(definition, key);
+            return true;
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or ArgumentException)
+        {
+            timestamp = default;
+            return false;
+        }
+    }
+}

--- a/tests/KeeperData.Core.Tests.Unit/EtlPipeline/EtlPipelineFactoryTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/EtlPipeline/EtlPipelineFactoryTests.cs
@@ -1,6 +1,9 @@
 using FluentAssertions;
 using KeeperData.Core.ETL.Abstract;
 using KeeperData.Core.EtlPipeline;
+using KeeperData.Core.EtlPipeline.Stages;
+using KeeperData.Core.Tests.Unit.EtlPipeline.Harness;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
 namespace KeeperData.Core.Tests.Unit.EtlPipeline;
@@ -12,7 +15,11 @@ public class EtlPipelineFactoryTests
     [Fact]
     public void Create_defines_every_stage_in_order()
     {
-        var factory = new EtlPipelineFactory(Mock.Of<IExternalCatalogueServiceFactory>());
+        var factory = new EtlPipelineFactory(
+            Mock.Of<IExternalCatalogueServiceFactory>(),
+            new InMemoryEtlPipelineStorage(),
+            TimeProvider.System,
+            NullLogger<SnapshotStage>.Instance);
 
         factory.Create().GetStageNames().Should().Equal(
             "discover",

--- a/tests/KeeperData.Core.Tests.Unit/EtlPipeline/Harness/InMemoryEtlPipelineStorage.cs
+++ b/tests/KeeperData.Core.Tests.Unit/EtlPipeline/Harness/InMemoryEtlPipelineStorage.cs
@@ -1,0 +1,132 @@
+using System.Collections.Concurrent;
+using KeeperData.Core.EtlPipeline.Storage;
+using KeeperData.Core.Storage;
+using KeeperData.Core.Storage.Dtos;
+
+namespace KeeperData.Core.Tests.Unit.EtlPipeline.Harness;
+
+/// <summary>In-memory <see cref="IEtlPipelineStorageProvider"/>, one folder per storage service,
+/// so a stage can be exercised against the pipeline folders without S3 or the file system.</summary>
+public sealed class InMemoryEtlPipelineStorage : IEtlPipelineStorageProvider
+{
+    private readonly ConcurrentDictionary<string, InMemoryBlobStorage> _folders = new();
+
+    public InMemoryBlobStorage Folder(string folder) => _folders.GetOrAdd(folder, name => new InMemoryBlobStorage(name));
+
+    public IBlobStorageService ForFolder(string folder) => Folder(folder);
+}
+
+public sealed class InMemoryBlobStorage(string container) : IBlobStorageService
+{
+    private readonly Dictionary<string, (byte[] Content, Dictionary<string, string> Metadata)> _objects = [];
+
+    public IReadOnlyCollection<string> Keys => [.. _objects.Keys];
+
+    public void Put(string objectKey, string content, IReadOnlyDictionary<string, string>? metadata = null)
+        => _objects[objectKey] = (System.Text.Encoding.UTF8.GetBytes(content), metadata?.ToDictionary() ?? []);
+
+    public string ContentOf(string objectKey) => System.Text.Encoding.UTF8.GetString(_objects[objectKey].Content);
+
+    public IReadOnlyDictionary<string, string> MetadataOf(string objectKey) => _objects[objectKey].Metadata;
+
+    public Task<IReadOnlyList<StorageObjectInfo>> ListAsync(string? prefix = null, CancellationToken cancellationToken = default)
+        => Task.FromResult<IReadOnlyList<StorageObjectInfo>>(
+            [.. _objects.Keys
+                .Where(key => prefix is null || key.StartsWith(prefix, StringComparison.Ordinal))
+                .OrderBy(key => key, StringComparer.Ordinal)
+                .Select(Info)]);
+
+    public Task<StorageObjectMetadata> GetMetadataAsync(string objectKey, CancellationToken cancellationToken = default)
+    {
+        var entry = _objects[objectKey];
+
+        return Task.FromResult(new StorageObjectMetadata
+        {
+            Container = container,
+            Key = objectKey,
+            ContentLength = entry.Content.Length,
+            StorageUri = Uri(objectKey),
+            UserMetadata = entry.Metadata
+        });
+    }
+
+    public Task<byte[]> DownloadAsync(string objectKey, CancellationToken cancellationToken = default)
+        => Task.FromResult(_objects[objectKey].Content);
+
+    public Task<Stream> OpenReadAsync(string objectKey, CancellationToken cancellationToken = default)
+        => Task.FromResult<Stream>(new MemoryStream(_objects[objectKey].Content, writable: false));
+
+    public Task<bool> ExistsAsync(string objectKey, CancellationToken cancellationToken = default)
+        => Task.FromResult(_objects.ContainsKey(objectKey));
+
+    public Task UploadAsync(
+        string objectKey,
+        byte[] content,
+        string? contentType = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default)
+    {
+        _objects[objectKey] = (content, metadata?.ToDictionary() ?? []);
+        return Task.CompletedTask;
+    }
+
+    public Task<Stream> OpenWriteAsync(
+        string objectKey,
+        string? contentType = null,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        int partSizeBytes = 8 * 1024 * 1024,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult<Stream>(new CommitOnDisposeStream(content => _objects[objectKey] = (content, metadata?.ToDictionary() ?? [])));
+
+    public Task SetMetadataAsync(string objectKey, IReadOnlyDictionary<string, string> metadata, CancellationToken cancellationToken = default)
+    {
+        var entry = _objects[objectKey];
+        _objects[objectKey] = (entry.Content, metadata.ToDictionary());
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(string objectKey, CancellationToken cancellationToken = default)
+    {
+        _objects.Remove(objectKey);
+        return Task.CompletedTask;
+    }
+
+    public Task<ClearDownResult> ClearDownAsync(CancellationToken cancellationToken = default)
+    {
+        var keys = _objects.Keys.ToList();
+        _objects.Clear();
+        return Task.FromResult(new ClearDownResult { DeletedKeys = keys, TotalDeleted = keys.Count });
+    }
+
+    public Task<StorageListPage> ListPageAsync(
+        string? prefix = null,
+        int pageSize = 1000,
+        string? continuationToken = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotSupportedException();
+
+    public string GeneratePresignedUrl(string objectKey, TimeSpan? expiresIn = null) => Uri(objectKey).ToString();
+
+    private StorageObjectInfo Info(string objectKey) => new()
+    {
+        Container = container,
+        Key = objectKey,
+        Size = _objects[objectKey].Content.Length,
+        StorageUri = Uri(objectKey)
+    };
+
+    private Uri Uri(string objectKey) => new($"memory://{container}/{objectKey}");
+
+    private sealed class CommitOnDisposeStream(Action<byte[]> commit) : MemoryStream
+    {
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                commit(ToArray());
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/KeeperData.Core.Tests.Unit/EtlPipeline/SnapshotFileNamingTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/EtlPipeline/SnapshotFileNamingTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using KeeperData.Core.EtlPipeline.Storage;
+using KeeperData.Core.Tests.Unit.EtlPipeline.Harness;
+
+namespace KeeperData.Core.Tests.Unit.EtlPipeline;
+
+public class SnapshotFileNamingTests
+{
+    [Fact]
+    public void SnapshotKey_uses_the_clean_dataset_name_and_the_etl_timestamp()
+    {
+        var key = SnapshotFileNaming.SnapshotKey(
+            StageRunner.Definition("sam_cph_holdings"),
+            new DateTimeOffset(2026, 07, 28, 11, 22, 33, TimeSpan.Zero));
+
+        key.Should().Be("sam_cph_holdings/sam_cph_holdings_20260728112233.parquet");
+    }
+
+    [Fact]
+    public void SnapshotKey_uses_the_utc_form_of_the_timestamp()
+    {
+        var key = SnapshotFileNaming.SnapshotKey(
+            StageRunner.Definition("sam_cph_holdings"),
+            new DateTimeOffset(2026, 07, 28, 12, 22, 33, TimeSpan.FromHours(1)));
+
+        key.Should().EndWith("_20260728112233.parquet");
+    }
+
+    [Fact]
+    public void LatestByTimestamp_picks_the_newest_and_ignores_unparsable_keys()
+    {
+        var latest = SnapshotFileNaming.LatestByTimestamp(
+            StageRunner.Definition("sam_cph_holdings"),
+            [
+                "sam_cph_holdings/sam_cph_holdings.parquet",
+                "sam_cph_holdings/sam_cph_holdings_20260701000000.parquet",
+                "sam_cph_holdings/sam_cph_holdings_20260715000000.parquet"
+            ]);
+
+        latest.Should().Be("sam_cph_holdings/sam_cph_holdings_20260715000000.parquet");
+    }
+
+    [Fact]
+    public void LatestByTimestamp_returns_null_when_nothing_is_usable()
+    {
+        SnapshotFileNaming.LatestByTimestamp(StageRunner.Definition(), ["no-timestamp.parquet"]).Should().BeNull();
+    }
+}

--- a/tests/KeeperData.Core.Tests.Unit/EtlPipeline/SnapshotStageTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/EtlPipeline/SnapshotStageTests.cs
@@ -1,25 +1,157 @@
 using FluentAssertions;
+using KeeperData.Core.ETL.Impl;
 using KeeperData.Core.EtlPipeline.Payloads;
 using KeeperData.Core.EtlPipeline.Stages;
+using KeeperData.Core.EtlPipeline.Storage;
 using KeeperData.Core.Tests.Unit.EtlPipeline.Harness;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 
 namespace KeeperData.Core.Tests.Unit.EtlPipeline;
 
 /// <summary>Snapshot. Input: NormalisedFileSet. Output: SnapshotFile.
-/// OWNER: implement the fold, then assert one snapshot per dataset with deltas applied.</summary>
+/// Snapshot mode only: the latest normalised parquet is copied to snapshots/ under the dataset's
+/// clean name and a fresh ETL timestamp.</summary>
 public class SnapshotStageTests
 {
-    private static Task<List<SnapshotFile>> RunAsync(params NormalisedFileSet[] inputs) =>
-        StageRunner.RunAsync(new SnapshotStage(), inputs);
+    private static readonly DataSetDefinition SamCph = StageRunner.Definition("sam_cph_holdings");
+
+    private readonly InMemoryEtlPipelineStorage _storage = new();
+    private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(2026, 07, 28, 11, 22, 33, TimeSpan.Zero));
+
+    private InMemoryBlobStorage Normalised => _storage.Folder(EtlPipelineFolders.Normalised);
+    private InMemoryBlobStorage Snapshots => _storage.Folder(EtlPipelineFolders.Snapshots);
+
+    private Task<List<SnapshotFile>> RunAsync(params NormalisedFileSet[] inputs) =>
+        StageRunner.RunAsync(new SnapshotStage(_storage, _timeProvider, NullLogger<SnapshotStage>.Instance), inputs);
 
     [Fact]
-    public async Task Produces_one_snapshot_per_input()
+    public async Task Writes_a_snapshot_named_after_the_dataset_and_the_etl_timestamp()
     {
-        var output = await RunAsync(
-            new NormalisedFileSet(StageRunner.Definition("SAM_CPH")),
-            new NormalisedFileSet(StageRunner.Definition("CTS_KEEPER")));
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "rows");
 
-        output.Should().HaveCount(2);
+        var output = await RunAsync(new NormalisedFileSet(SamCph));
+
+        output.Should().ContainSingle()
+            .Which.Key.Should().Be("sam_cph_holdings/sam_cph_holdings_20260728112233.parquet");
+        Snapshots.ContentOf("sam_cph_holdings/sam_cph_holdings_20260728112233.parquet").Should().Be("rows");
+    }
+
+    [Fact]
+    public async Task Snapshots_the_latest_normalised_file_by_filename_timestamp()
+    {
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "old");
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260715000000.parquet", "new");
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260710000000.parquet", "middle");
+
+        var output = await RunAsync(new NormalisedFileSet(SamCph));
+
+        output.Single().SourceKey.Should().Be("sam_cph_holdings/sam_cph_holdings_20260715000000.parquet");
+        Snapshots.ContentOf(output.Single().Key).Should().Be("new");
+    }
+
+    [Fact]
+    public async Task Prefers_the_files_carried_by_the_payload_over_listing_the_folder()
+    {
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "listed");
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260715000000.parquet", "supplied");
+
+        var output = await RunAsync(new NormalisedFileSet(SamCph)
+        {
+            Files = ["sam_cph_holdings/sam_cph_holdings_20260701000000.parquet"]
+        });
+
+        output.Single().SourceKey.Should().Be("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet");
+    }
+
+    [Fact]
+    public async Task Does_not_create_a_duplicate_snapshot_when_there_is_no_new_normalised_file()
+    {
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "rows");
+
+        var first = await RunAsync(new NormalisedFileSet(SamCph));
+
+        _timeProvider.Advance(TimeSpan.FromHours(1));
+
+        var second = await RunAsync(new NormalisedFileSet(SamCph));
+
+        second.Single().Key.Should().Be(first.Single().Key);
+        second.Single().Created.Should().BeFalse();
+        Snapshots.Keys.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Creates_a_new_snapshot_when_a_newer_normalised_file_arrives()
+    {
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "rows");
+        await RunAsync(new NormalisedFileSet(SamCph));
+
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260702000000.parquet", "more rows");
+        _timeProvider.Advance(TimeSpan.FromHours(1));
+
+        var output = await RunAsync(new NormalisedFileSet(SamCph));
+
+        output.Single().Created.Should().BeTrue();
+        Snapshots.Keys.Should().HaveCount(2);
+        Snapshots.ContentOf(output.Single().Key).Should().Be("more rows");
+    }
+
+    [Fact]
+    public async Task Never_overwrites_an_existing_snapshot_file()
+    {
+        var key = "sam_cph_holdings/sam_cph_holdings_20260728112233.parquet";
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "rows");
+        Snapshots.Put(key, "written by someone else");
+
+        var output = await RunAsync(new NormalisedFileSet(SamCph));
+
+        output.Should().BeEmpty();
+        Snapshots.ContentOf(key).Should().Be("written by someone else");
+    }
+
+    [Fact]
+    public async Task Records_the_normalised_file_the_snapshot_came_from()
+    {
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "rows");
+
+        var output = await RunAsync(new NormalisedFileSet(SamCph));
+
+        Snapshots.MetadataOf(output.Single().Key)[EtlConstants.MetadataKeySnapshotSourceKey]
+            .Should().Be("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet");
+    }
+
+    [Fact]
+    public async Task Produces_nothing_when_the_dataset_has_no_normalised_file()
+    {
+        var output = await RunAsync(new NormalisedFileSet(SamCph));
+
+        output.Should().BeEmpty();
+        Snapshots.Keys.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Ignores_normalised_files_whose_name_carries_no_timestamp()
+    {
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings.parquet", "unnamed");
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "rows");
+
+        var output = await RunAsync(new NormalisedFileSet(SamCph));
+
+        output.Single().SourceKey.Should().Be("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet");
+    }
+
+    [Fact]
+    public async Task Produces_one_snapshot_per_dataset()
+    {
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "sam");
+        Normalised.Put("cts_keeper/cts_keeper_20260701000000.parquet", "cts");
+
+        var output = await RunAsync(
+            new NormalisedFileSet(SamCph),
+            new NormalisedFileSet(StageRunner.Definition("cts_keeper")));
+
+        output.Select(o => o.Definition.Name).Should().Equal("sam_cph_holdings", "cts_keeper");
+        Snapshots.Keys.Should().HaveCount(2);
     }
 
     [Fact]
@@ -28,5 +160,27 @@ public class SnapshotStageTests
         var output = await RunAsync();
 
         output.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task The_latest_snapshot_is_the_one_with_the_newest_etl_timestamp()
+    {
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "first");
+        var first = await RunAsync(new NormalisedFileSet(SamCph));
+
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260702000000.parquet", "second");
+        _timeProvider.Advance(TimeSpan.FromHours(1));
+        var second = await RunAsync(new NormalisedFileSet(SamCph));
+
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260703000000.parquet", "third");
+        _timeProvider.Advance(TimeSpan.FromHours(1));
+        var third = await RunAsync(new NormalisedFileSet(SamCph));
+
+        var allKeys = Snapshots.Keys.ToList();
+        allKeys.Should().HaveCount(3);
+
+        var latest = SnapshotFileNaming.LatestByTimestamp(SamCph, allKeys);
+
+        latest.Should().Be(third.Single().Key);
     }
 }


### PR DESCRIPTION
Implement a new snapshotting mechanism in the ETL pipeline. The SnapshotStage now creates one canonical Parquet file per dataset, named with the dataset's clean name and ETL timestamp. Snapshots are only created for new normalised files; otherwise, existing snapshots are reused. The snapshot file's metadata records the source normalised file for idempotency. Introduce SnapshotFileNaming for naming and timestamp logic, with unit tests. Update pipeline factory and fluent extensions for dependency injection. Add in-memory storage for testing and extend SnapshotFile payload with key, source key, timestamp, and creation status.