### PR TITLE
Feature/lkpr 88 - Refactor ETL snapshotting: add delta merge & Parquet- #207

### DIFF
--- a/src/KeeperData.Core/ETL/Impl/DataSetDefinitions.cs
+++ b/src/KeeperData.Core/ETL/Impl/DataSetDefinitions.cs
@@ -4,7 +4,7 @@ using System.Collections.Immutable;
 namespace KeeperData.Core.ETL.Impl;
 
 
-public record DataSetDefinition(string Name, string FilePrefixFormat, string[] PrimaryKeyHeaderNames, string ChangeTypeHeaderName, string[] Accumulators, string DatePattern = EtlConstants.DatePattern, string DateTimePattern = EtlConstants.DateTimePattern);
+public record DataSetDefinition(string Name, string FilePrefixFormat, string[] PrimaryKeyHeaderNames, string ChangeTypeHeaderName, string[] Accumulators, string DatePattern = EtlConstants.DatePattern, string DateTimePattern = EtlConstants.DateTimePattern, DataSetIngestionMode IngestionMode = DataSetIngestionMode.Snapshot);
 
 public class DataSetDefinitions : IDataSetDefinitions
 {

--- a/src/KeeperData.Core/ETL/Impl/DataSetIngestionMode.cs
+++ b/src/KeeperData.Core/ETL/Impl/DataSetIngestionMode.cs
@@ -1,0 +1,7 @@
+namespace KeeperData.Core.ETL.Impl;
+
+public enum DataSetIngestionMode
+{
+    Snapshot = 0,
+    Delta = 1
+}

--- a/src/KeeperData.Core/ETL/Impl/StandardDataSetDefinitionsBuilder.cs
+++ b/src/KeeperData.Core/ETL/Impl/StandardDataSetDefinitionsBuilder.cs
@@ -5,7 +5,7 @@ public static class StandardDataSetDefinitionsBuilder
     public static DataSetDefinitions Build()
     {
         var list = new List<DataSetDefinition>();
-        var samCPHHolding = list.With(new DataSetDefinition("sam_cph_holdings", "LITP_SAMCPHHOLDING_{0}", ["CPH", "FEATURE_NAME", "SECONDARY_CPH", "ANIMAL_SPECIES_CODE"], ChangeType.HeaderName, []));
+        var samCPHHolding = list.With(new DataSetDefinition("sam_cph_holdings", "LITP_SAMCPHHOLDING_{0}", ["CPH", "FEATURE_NAME", "SECONDARY_CPH", "ANIMAL_SPECIES_CODE"], ChangeType.HeaderName, [], IngestionMode: DataSetIngestionMode.Delta));
         var ctscphHolding = list.With(new DataSetDefinition("cts_cph_holding", "LITP_CTSCPHHOLDING_{0}", ["LID_FULL_IDENTIFIER"], ChangeType.HeaderName, []));
         var ctsKeeper = list.With(new DataSetDefinition("cts_keeper", "LITP_CTSKEEPER_{0}", ["PAR_ID", "LID_FULL_IDENTIFIER"], ChangeType.HeaderName, []));
         var samCPHHolder = list.With(new DataSetDefinition("sam_cph_holder", "LITP_SAMCPHHOLDER_{0}", ["PARTY_ID"], ChangeType.HeaderName, []));

--- a/src/KeeperData.Core/EtlConstants.cs
+++ b/src/KeeperData.Core/EtlConstants.cs
@@ -12,7 +12,4 @@ public static class EtlConstants
     // S3 automatically prefixes user metadata with "x-amz-meta-" and lowercases the keys
     public const string MetadataKeySourceEncryptedLength = "x-amz-meta-sourceencryptedlength";
     public const string MetadataKeySourceETag = "x-amz-meta-sourceetag";
-
-    /// <summary>The normalised file key a snapshot was produced from.</summary>
-    public const string MetadataKeySnapshotSourceKey = "x-amz-meta-snapshotsourcekey";
 }

--- a/src/KeeperData.Core/EtlPipeline/Payloads/SnapshotFile.cs
+++ b/src/KeeperData.Core/EtlPipeline/Payloads/SnapshotFile.cs
@@ -9,9 +9,20 @@ public sealed record SnapshotFile(DataSetDefinition Definition)
 
     public string Key { get; init; } = string.Empty;
 
-    public string SourceKey { get; init; } = string.Empty;
+    /// <summary>The latest source timestamp the snapshot includes, read from the name of the newest
+    /// file applied. Not the time the ETL ran.</summary>
+    public DateTimeOffset SourceTimestamp { get; init; }
 
-    public DateTimeOffset Timestamp { get; init; }
+    /// <summary>The normalised files this run folded in, oldest first. Empty when the run had nothing
+    /// new to apply and reused the existing snapshot.</summary>
+    public IReadOnlyList<string> AppliedKeys { get; init; } = [];
 
     public bool Created { get; init; }
+
+    public long RowCount { get; init; }
+
+    public long RowsUpserted { get; init; }
+
+    /// <summary>Rows carrying CHANGE_TYPE = D. Counted for visibility; deletes are not applied.</summary>
+    public long RowsIgnoredDeletes { get; init; }
 }

--- a/src/KeeperData.Core/EtlPipeline/Setup/ServiceCollectionExtensions.cs
+++ b/src/KeeperData.Core/EtlPipeline/Setup/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using KeeperData.Core.EtlPipeline.Snapshots;
 using KeeperData.Core.EtlPipeline.Stages;
 using KeeperData.Core.Pipeline;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +14,8 @@ public static class ServiceCollectionExtensions
 
         services.AddScoped<IPipelineExecutor, PipelineExecutor>();
         services.AddScoped<IEtlPipelineFactory, EtlPipelineFactory>();
+
+        services.TryAddScoped<IDeltaMergeEngine, ParquetDeltaMergeEngine>();
 
         services.AddScoped<DecryptStage>();
         services.AddScoped<SnapshotStage>();

--- a/src/KeeperData.Core/EtlPipeline/Snapshots/DeltaMergeResult.cs
+++ b/src/KeeperData.Core/EtlPipeline/Snapshots/DeltaMergeResult.cs
@@ -1,0 +1,12 @@
+using KeeperData.Core.ETL.Impl;
+
+namespace KeeperData.Core.EtlPipeline.Snapshots;
+
+public sealed record DeltaMergeResult
+{
+    public int DeltasApplied { get; init; }
+    public long RowsUpserted { get; init; }
+    public long RowsIgnoredDeletes { get; init; }
+    public long RowsRejected { get; init; }
+    public long RowCount { get; init; }
+}

--- a/src/KeeperData.Core/EtlPipeline/Snapshots/DeltaMergeSource.cs
+++ b/src/KeeperData.Core/EtlPipeline/Snapshots/DeltaMergeSource.cs
@@ -1,0 +1,3 @@
+namespace KeeperData.Core.EtlPipeline.Snapshots;
+
+public sealed record DeltaMergeSource(string Key, Func<CancellationToken, Task<Stream>> Open);

--- a/src/KeeperData.Core/EtlPipeline/Snapshots/IDeltaMergeEngine.cs
+++ b/src/KeeperData.Core/EtlPipeline/Snapshots/IDeltaMergeEngine.cs
@@ -1,0 +1,13 @@
+using KeeperData.Core.ETL.Impl;
+
+namespace KeeperData.Core.EtlPipeline.Snapshots;
+
+public interface IDeltaMergeEngine
+{
+    Task<DeltaMergeResult> MergeAsync(
+        DataSetDefinition definition,
+        DeltaMergeSource? baseSnapshot,
+        IReadOnlyList<DeltaMergeSource> deltas,
+        Stream output,
+        CancellationToken cancellationToken = default);
+}

--- a/src/KeeperData.Core/EtlPipeline/Snapshots/MergeState.cs
+++ b/src/KeeperData.Core/EtlPipeline/Snapshots/MergeState.cs
@@ -1,0 +1,141 @@
+using KeeperData.Core.ETL.Impl;
+using Parquet;
+using Parquet.Data;
+using Parquet.Schema;
+
+namespace KeeperData.Core.EtlPipeline.Snapshots;
+
+public sealed partial class ParquetDeltaMergeEngine
+{
+    /// <summary>The merged rows, held in insertion order so the output is deterministic.</summary>
+    private sealed class MergeState(DataSetDefinition definition)
+    {
+        private readonly Dictionary<string, int> _indexByKey = new(StringComparer.Ordinal);
+        private readonly List<object?[]> _rows = [];
+
+        private DataField[]? _fields;
+
+        public long RowCount => _rows.Count;
+
+        public void SeedFrom(ParquetTable table, string key)
+        {
+            _fields = table.Fields.Where(field => !IsChangeType(field.Name)).ToArray();
+
+            foreach (var row in table.Rows)
+            {
+                Upsert(Project(table, row, key), CompositeKey(table, row, key));
+            }
+        }
+
+        public (long Upserted, long IgnoredDeletes, long Rejected) Apply(ParquetTable table, string key)
+        {
+            _fields ??= table.Fields.Where(field => !IsChangeType(field.Name)).ToArray();
+
+            var changeTypeIndex = table.IndexOf(definition.ChangeTypeHeaderName);
+
+            var upserted = 0L;
+            var ignoredDeletes = 0L;
+            var rejected = 0L;
+
+            foreach (var row in table.Rows)
+            {
+                var changeType = changeTypeIndex < 0 ? ChangeType.Insert : Text(row[changeTypeIndex]);
+
+                switch (changeType)
+                {
+                    case ChangeType.Insert:
+                    case ChangeType.Update:
+                        Upsert(Project(table, row, key), CompositeKey(table, row, key));
+                        upserted++;
+                        break;
+
+                    // Delete processing is out of scope: the row is counted and left in the snapshot.
+                    case ChangeType.Delete:
+                        ignoredDeletes++;
+                        break;
+
+                    default:
+                        rejected++;
+                        break;
+                }
+            }
+
+            return (upserted, ignoredDeletes, rejected);
+        }
+
+        public async Task WriteAsync(Stream output, CancellationToken cancellationToken)
+        {
+            var fields = _fields
+                ?? throw new InvalidOperationException($"Nothing to write for dataset '{definition.Name}': no file supplied a schema");
+
+            using var writer = await ParquetWriter.CreateAsync(new ParquetSchema(fields), output, cancellationToken: cancellationToken);
+            using var rowGroup = writer.CreateRowGroup();
+
+            for (var column = 0; column < fields.Length; column++)
+            {
+                var values = Array.CreateInstance(fields[column].ClrNullableIfHasNullsType, _rows.Count);
+
+                for (var row = 0; row < _rows.Count; row++)
+                {
+                    values.SetValue(_rows[row][column], row);
+                }
+
+                await rowGroup.WriteColumnAsync(new DataColumn(fields[column], values), cancellationToken);
+            }
+        }
+
+        /// <summary>The row reduced to the output columns, in output column order.</summary>
+        private object?[] Project(ParquetTable table, object?[] row, string key)
+        {
+            var fields = _fields!;
+            var projected = new object?[fields.Length];
+
+            for (var column = 0; column < fields.Length; column++)
+            {
+                var index = table.IndexOf(fields[column].Name);
+
+                if (index < 0)
+                {
+                    throw new InvalidOperationException(
+                        $"'{key}' has no column '{fields[column].Name}' expected by dataset '{definition.Name}'");
+                }
+
+                projected[column] = row[index];
+            }
+
+            return projected;
+        }
+
+        private void Upsert(object?[] row, string compositeKey)
+        {
+            if (_indexByKey.TryGetValue(compositeKey, out var existing))
+            {
+                _rows[existing] = row;
+                return;
+            }
+
+            _indexByKey[compositeKey] = _rows.Count;
+            _rows.Add(row);
+        }
+
+        private string CompositeKey(ParquetTable table, object?[] row, string key)
+        {
+            var parts = definition.PrimaryKeyHeaderNames.Select(name =>
+            {
+                var index = table.IndexOf(name);
+
+                return index < 0
+                    ? throw new InvalidOperationException(
+                        $"'{key}' has no primary key column '{name}' for dataset '{definition.Name}'")
+                    : Text(row[index]);
+            });
+
+            return string.Join(EtlConstants.CompositeKeyDelimiter, parts);
+        }
+
+        private bool IsChangeType(string name)
+            => string.Equals(name, definition.ChangeTypeHeaderName, StringComparison.OrdinalIgnoreCase);
+
+        private static string Text(object? value) => value?.ToString() ?? string.Empty;
+    }
+}

--- a/src/KeeperData.Core/EtlPipeline/Snapshots/NonDisposingStream.cs
+++ b/src/KeeperData.Core/EtlPipeline/Snapshots/NonDisposingStream.cs
@@ -1,0 +1,25 @@
+namespace KeeperData.Core.EtlPipeline.Snapshots;
+
+public sealed partial class ParquetDeltaMergeEngine
+{
+    /// <summary>Lets the reader own a stream it must not close, because the caller disposes it.</summary>
+    private sealed class NonDisposingStream(Stream inner) : Stream
+    {
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override void Flush() => inner.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/src/KeeperData.Core/EtlPipeline/Snapshots/ParquetDeltaMergeEngine.cs
+++ b/src/KeeperData.Core/EtlPipeline/Snapshots/ParquetDeltaMergeEngine.cs
@@ -1,0 +1,88 @@
+using KeeperData.Core.ETL.Impl;
+using Microsoft.Extensions.Logging;
+
+namespace KeeperData.Core.EtlPipeline.Snapshots;
+
+/// <summary>Folds deltas onto a base snapshot in memory and writes the result as Parquet.
+///
+/// The state is keyed by the dataset's primary keys, so a row arriving again replaces the one already
+/// held (last writer wins) and an unseen key is appended. The change type column describes the delta,
+/// not the resulting state, so it is dropped from the output.</summary>
+public sealed partial class ParquetDeltaMergeEngine(ILogger<ParquetDeltaMergeEngine> logger) : IDeltaMergeEngine
+{
+    public async Task<DeltaMergeResult> MergeAsync(
+        DataSetDefinition definition,
+        DeltaMergeSource? baseSnapshot,
+        IReadOnlyList<DeltaMergeSource> deltas,
+        Stream output,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(deltas);
+        ArgumentNullException.ThrowIfNull(output);
+
+        var state = new MergeState(definition);
+
+        if (baseSnapshot is not null)
+        {
+            var table = await ReadAsync(baseSnapshot, cancellationToken);
+            state.SeedFrom(table, baseSnapshot.Key);
+        }
+
+        var upserted = 0L;
+        var ignoredDeletes = 0L;
+        var rejected = 0L;
+
+        foreach (var delta in deltas)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var (Upserted, IgnoredDeletes, Rejected) = await ApplyDeltaAsync(state, delta, definition, cancellationToken);
+
+            upserted += Upserted;
+            ignoredDeletes += IgnoredDeletes;
+            rejected += Rejected;
+        }
+
+        await state.WriteAsync(output, cancellationToken);
+
+        return new DeltaMergeResult
+        {
+            DeltasApplied = deltas.Count,
+            RowsUpserted = upserted,
+            RowsIgnoredDeletes = ignoredDeletes,
+            RowsRejected = rejected,
+            RowCount = state.RowCount
+        };
+    }
+
+    private async Task<(long Upserted, long IgnoredDeletes, long Rejected)> ApplyDeltaAsync(
+        MergeState state,
+        DeltaMergeSource delta,
+        DataSetDefinition definition,
+        CancellationToken cancellationToken)
+    {
+        var table = await ReadAsync(delta, cancellationToken);
+        var applied = state.Apply(table, delta.Key);
+
+        if (applied.Rejected > 0)
+        {
+            logger.LogWarning(
+                "Ignored {RejectedRows} row(s) with an unrecognised {ChangeTypeColumn} in {DeltaKey} for dataset {DataSet}",
+                applied.Rejected, definition.ChangeTypeHeaderName, delta.Key, definition.Name);
+        }
+
+        logger.LogInformation(
+            "Applied delta {DeltaKey} to dataset {DataSet}: {Upserted} upserted, {IgnoredDeletes} delete row(s) ignored",
+            delta.Key, definition.Name, applied.Upserted, applied.IgnoredDeletes);
+
+        return applied;
+    }
+
+    private static async Task<ParquetTable> ReadAsync(DeltaMergeSource source, CancellationToken cancellationToken)
+    {
+        await using var stream = await source.Open(cancellationToken);
+
+        return await ParquetTable.ReadAsync(stream, source.Key, cancellationToken);
+    }
+}

--- a/src/KeeperData.Core/EtlPipeline/Snapshots/ParquetDeltaMergeEngine.cs
+++ b/src/KeeperData.Core/EtlPipeline/Snapshots/ParquetDeltaMergeEngine.cs
@@ -25,7 +25,7 @@ public sealed partial class ParquetDeltaMergeEngine(ILogger<ParquetDeltaMergeEng
 
         if (baseSnapshot is not null)
         {
-            var table = await ReadAsync(baseSnapshot, cancellationToken);
+            var table = await ReadTableAsync(baseSnapshot, cancellationToken);
             state.SeedFrom(table, baseSnapshot.Key);
         }
 
@@ -62,7 +62,7 @@ public sealed partial class ParquetDeltaMergeEngine(ILogger<ParquetDeltaMergeEng
         DataSetDefinition definition,
         CancellationToken cancellationToken)
     {
-        var table = await ReadAsync(delta, cancellationToken);
+        var table = await ReadTableAsync(delta, cancellationToken);
         var applied = state.Apply(table, delta.Key);
 
         if (applied.Rejected > 0)
@@ -79,7 +79,7 @@ public sealed partial class ParquetDeltaMergeEngine(ILogger<ParquetDeltaMergeEng
         return applied;
     }
 
-    private static async Task<ParquetTable> ReadAsync(DeltaMergeSource source, CancellationToken cancellationToken)
+    private static async Task<ParquetTable> ReadTableAsync(DeltaMergeSource source, CancellationToken cancellationToken)
     {
         await using var stream = await source.Open(cancellationToken);
 

--- a/src/KeeperData.Core/EtlPipeline/Snapshots/ParquetTable.cs
+++ b/src/KeeperData.Core/EtlPipeline/Snapshots/ParquetTable.cs
@@ -1,0 +1,104 @@
+using Parquet;
+using Parquet.Schema;
+
+namespace KeeperData.Core.EtlPipeline.Snapshots;
+
+public sealed partial class ParquetDeltaMergeEngine
+{
+    /// <summary>One Parquet file read into rows, so the merge works one file at a time rather than
+    /// column-at-a-time across files.</summary>
+    private sealed class ParquetTable
+    {
+        private readonly Dictionary<string, int> _indexByName = new(StringComparer.OrdinalIgnoreCase);
+
+        private ParquetTable(DataField[] fields, List<object?[]> rows)
+        {
+            Fields = fields;
+            Rows = rows;
+
+            for (var index = 0; index < fields.Length; index++)
+            {
+                _indexByName.TryAdd(fields[index].Name, index);
+            }
+        }
+
+        public DataField[] Fields { get; }
+
+        public List<object?[]> Rows { get; }
+
+        public int IndexOf(string name) => _indexByName.TryGetValue(name, out var index) ? index : -1;
+
+        public static async Task<ParquetTable> ReadAsync(Stream stream, string key, CancellationToken cancellationToken)
+        {
+            await using var seekable = await AsSeekableAsync(stream, cancellationToken);
+            using var reader = await ParquetReader.CreateAsync(seekable, cancellationToken: cancellationToken);
+
+            var fields = reader.Schema.GetDataFields();
+            var rows = await ReadRowsAsync(reader, fields, cancellationToken);
+
+            return fields.Length == 0 && rows.Count == 0
+                ? throw new InvalidOperationException($"'{key}' carries no columns")
+                : new ParquetTable(fields, rows);
+        }
+
+        private static async Task<List<object?[]>> ReadRowsAsync(ParquetReader reader, DataField[] fields, CancellationToken cancellationToken)
+        {
+            var rows = new List<object?[]>();
+
+            for (var group = 0; group < reader.RowGroupCount; group++)
+            {
+                using var rowGroup = reader.OpenRowGroupReader(group);
+                var columns = await ReadColumnsAsync(rowGroup, fields, cancellationToken);
+                AppendRows(rows, columns, fields.Length);
+            }
+
+            return rows;
+        }
+
+        private static async Task<Array[]> ReadColumnsAsync(ParquetRowGroupReader rowGroup, DataField[] fields, CancellationToken cancellationToken)
+        {
+            var columns = new Array[fields.Length];
+
+            for (var column = 0; column < fields.Length; column++)
+            {
+                columns[column] = (await rowGroup.ReadColumnAsync(fields[column], cancellationToken)).Data;
+            }
+
+            return columns;
+        }
+
+        private static void AppendRows(List<object?[]> rows, Array[] columns, int fieldCount)
+        {
+            var count = columns.Length == 0 ? 0 : columns[0].Length;
+
+            for (var row = 0; row < count; row++)
+            {
+                var values = new object?[fieldCount];
+
+                for (var column = 0; column < fieldCount; column++)
+                {
+                    values[column] = columns[column].GetValue(row);
+                }
+
+                rows.Add(values);
+            }
+        }
+
+        /// <summary>Parquet is read back to front, so a forward-only stream (an object download) is
+        /// buffered first.</summary>
+        private static async Task<Stream> AsSeekableAsync(Stream stream, CancellationToken cancellationToken)
+        {
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+                return new NonDisposingStream(stream);
+            }
+
+            var buffer = new MemoryStream();
+            await stream.CopyToAsync(buffer, cancellationToken);
+            buffer.Position = 0;
+
+            return buffer;
+        }
+    }
+}

--- a/src/KeeperData.Core/EtlPipeline/Stages/SnapshotStage.cs
+++ b/src/KeeperData.Core/EtlPipeline/Stages/SnapshotStage.cs
@@ -112,7 +112,7 @@ public sealed class SnapshotStage(
         CancellationToken cancellationToken)
     {
         var definition = fileSet.Definition;
-        var workingFile = Path.GetTempFileName();
+        var workingFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
         try
         {

--- a/src/KeeperData.Core/EtlPipeline/Stages/SnapshotStage.cs
+++ b/src/KeeperData.Core/EtlPipeline/Stages/SnapshotStage.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using KeeperData.Core.ETL.Impl;
 using KeeperData.Core.EtlPipeline.Payloads;
+using KeeperData.Core.EtlPipeline.Snapshots;
 using KeeperData.Core.EtlPipeline.Storage;
 using KeeperData.Core.Pipeline;
 using KeeperData.Core.Storage;
@@ -8,18 +9,23 @@ using Microsoft.Extensions.Logging;
 
 namespace KeeperData.Core.EtlPipeline.Stages;
 
-/// <summary>Produces one canonical Parquet file per dataset in snapshots/, named with the dataset's
-/// clean name and a fresh ETL timestamp. Materialises: snapshots/.
+/// <summary>Produces one Parquet snapshot per dataset in snapshots/, named with the latest source
+/// timestamp it includes. Materialises: snapshots/.
 ///
-/// Snapshot mode only: the latest normalised file for the dataset (by the timestamp in its name) is
-/// copied as-is. Delta walking, primary-key matching and CHANGE_TYPE handling are deferred to LKPR-34.
+/// Every source file is a delta - the first one is simply the largest - so a dataset in
+/// <see cref="DataSetIngestionMode.Delta"/> folds each normalised file newer than the latest snapshot
+/// onto it, oldest first. With no snapshot yet the fold starts from nothing and every normalised file
+/// is applied. A dataset in <see cref="DataSetIngestionMode.Snapshot"/> keeps the simpler behaviour of
+/// copying its latest normalised file as-is.
 ///
-/// Idempotent: a snapshot records the normalised key it came from, so a re-run with no new normalised
-/// file reuses the existing snapshot instead of writing a duplicate. Existing snapshots are never
-/// overwritten and never deleted.</summary>
+/// Ordering comes from the timestamp in the file name and nothing else. A file whose name carries no
+/// timestamp, or two files carrying the same one, fail the import rather than being guessed at.
+///
+/// Resume state is the timestamp in the latest snapshot's own name: no metadata and no sidecar files.
+/// A re-run with nothing newer reuses that snapshot. Snapshots are never overwritten or deleted.</summary>
 public sealed class SnapshotStage(
     IEtlPipelineStorageProvider storageProvider,
-    TimeProvider timeProvider,
+    IDeltaMergeEngine mergeEngine,
     ILogger<SnapshotStage> logger) : IStage<NormalisedFileSet, SnapshotFile>
 {
     public string Name => "snapshot";
@@ -34,16 +40,16 @@ public sealed class SnapshotStage(
 
         await foreach (var fileSet in input.WithCancellation(cancellationToken))
         {
-            var snapshot = await SnapshotAsync(fileSet, normalised, snapshots, cancellationToken);
+            var outcome = await SnapshotAsync(fileSet, normalised, snapshots, cancellationToken);
 
-            if (snapshot is not null)
+            if (outcome is SnapshotOutcome.Produced { File: var snapshot })
             {
                 yield return snapshot;
             }
         }
     }
 
-    private async Task<SnapshotFile?> SnapshotAsync(
+    private async Task<SnapshotOutcome> SnapshotAsync(
         NormalisedFileSet fileSet,
         IBlobStorageService normalised,
         IBlobStorageService snapshots,
@@ -51,65 +57,167 @@ public sealed class SnapshotStage(
     {
         var definition = fileSet.Definition;
 
-        var sourceKey = SnapshotFileNaming.LatestByTimestamp(definition, await NormalisedKeysAsync(fileSet, normalised, cancellationToken));
+        var available = SnapshotFileNaming.OrderedByTimestamp(
+            definition, await NormalisedKeysAsync(fileSet, normalised, cancellationToken));
 
-        if (sourceKey is null)
+        if (available.Count == 0)
         {
             logger.LogInformation("No normalised file for dataset {DataSet}; no snapshot produced", definition.Name);
-            return null;
+            return SnapshotOutcome.None;
         }
 
-        var existing = await FindSnapshotForAsync(definition, sourceKey, snapshots, cancellationToken);
+        var current = await LatestSnapshotAsync(definition, snapshots, cancellationToken);
 
-        if (existing is not null)
+        var pending = current is null
+            ? available
+            : [.. available.Where(file => file.Timestamp > current.Timestamp)];
+
+        if (pending.Count == 0)
         {
             logger.LogInformation(
-                "Snapshot {SnapshotKey} already covers normalised file {SourceKey} for dataset {DataSet}; reusing it",
-                existing, sourceKey, definition.Name);
+                "Dataset {DataSet} has nothing newer than snapshot {SnapshotKey}; reusing it",
+                definition.Name, current!.Key);
 
-            if (!SnapshotFileNaming.TryExtractTimestamp(definition, existing, out var existingTimestamp))
+            return SnapshotOutcome.Of(Reused(fileSet, current));
+        }
+
+        var outputKey = SnapshotFileNaming.SnapshotKey(definition, pending[^1].Timestamp);
+
+        if (await snapshots.ExistsAsync(outputKey, cancellationToken))
+        {
+            logger.LogWarning(
+                "Snapshot {SnapshotKey} for dataset {DataSet} already exists and will not be overwritten",
+                outputKey, definition.Name);
+
+            return SnapshotOutcome.Of(Reused(fileSet, new TimestampedKey(outputKey, pending[^1].Timestamp)));
+        }
+
+        var file = definition.IngestionMode == DataSetIngestionMode.Delta
+            ? await MergeAsync(fileSet, current, pending, outputKey, normalised, snapshots, cancellationToken)
+            : await CopyAsync(fileSet, pending[^1], outputKey, normalised, snapshots, cancellationToken);
+
+        return SnapshotOutcome.Of(file);
+    }
+
+    /// <summary>Folds the pending deltas onto the current snapshot. The merge runs into a local
+    /// temporary file and is uploaded only once it has completed, so a failure part way through never
+    /// leaves a half-written object under the snapshot's key.</summary>
+    private async Task<SnapshotFile> MergeAsync(
+        NormalisedFileSet fileSet,
+        TimestampedKey? current,
+        IReadOnlyList<TimestampedKey> pending,
+        string outputKey,
+        IBlobStorageService normalised,
+        IBlobStorageService snapshots,
+        CancellationToken cancellationToken)
+    {
+        var definition = fileSet.Definition;
+        var workingFile = Path.GetTempFileName();
+
+        try
+        {
+            DeltaMergeResult result;
+
+            await using (var working = new FileStream(workingFile, FileMode.Create, FileAccess.ReadWrite))
             {
-                logger.LogWarning(
-                    "Could not parse timestamp from existing snapshot key {SnapshotKey} for dataset {DataSet}; Timestamp will be default",
-                    existing, definition.Name);
+                result = await mergeEngine.MergeAsync(
+                    definition,
+                    current is null ? null : Source(snapshots, current.Key),
+                    [.. pending.Select(file => Source(normalised, file.Key))],
+                    working,
+                    cancellationToken);
             }
+
+            await using (var published = await snapshots.OpenWriteAsync(
+                outputKey, SnapshotFileNaming.ParquetContentType, cancellationToken: cancellationToken))
+            {
+                await using var merged = new FileStream(workingFile, FileMode.Open, FileAccess.Read);
+                await merged.CopyToAsync(published, cancellationToken);
+            }
+
+            logger.LogInformation(
+                "Wrote snapshot {SnapshotKey} for dataset {DataSet} from {DeltaCount} delta(s) onto {BaseKey}: {RowCount} rows",
+                outputKey, definition.Name, pending.Count, current?.Key ?? "no previous snapshot", result.RowCount);
 
             return new SnapshotFile(definition)
             {
                 RunId = fileSet.RunId,
-                Key = existing,
-                SourceKey = sourceKey,
-                Timestamp = existingTimestamp,
-                Created = false
+                Key = outputKey,
+                SourceTimestamp = pending[^1].Timestamp,
+                AppliedKeys = [.. pending.Select(file => file.Key)],
+                Created = true,
+                RowCount = result.RowCount,
+                RowsUpserted = result.RowsUpserted,
+                RowsIgnoredDeletes = result.RowsIgnoredDeletes
             };
         }
-
-        var timestamp = timeProvider.GetUtcNow();
-        var snapshotKey = SnapshotFileNaming.SnapshotKey(definition, timestamp);
-
-        if (await snapshots.ExistsAsync(snapshotKey, cancellationToken))
+        finally
         {
-            logger.LogWarning(
-                "Snapshot {SnapshotKey} for dataset {DataSet} already exists and will not be overwritten",
-                snapshotKey, definition.Name);
-
-            return null;
+            File.Delete(workingFile);
         }
+    }
 
-        await CopyAsync(normalised, sourceKey, snapshots, snapshotKey, cancellationToken);
+    /// <summary>Snapshot mode: the latest normalised file becomes the snapshot unchanged.</summary>
+    private async Task<SnapshotFile> CopyAsync(
+        NormalisedFileSet fileSet,
+        TimestampedKey source,
+        string outputKey,
+        IBlobStorageService normalised,
+        IBlobStorageService snapshots,
+        CancellationToken cancellationToken)
+    {
+        await using (var reader = await normalised.OpenReadAsync(source.Key, cancellationToken))
+        {
+            await using var writer = await snapshots.OpenWriteAsync(
+                outputKey, SnapshotFileNaming.ParquetContentType, cancellationToken: cancellationToken);
+
+            await reader.CopyToAsync(writer, cancellationToken);
+        }
 
         logger.LogInformation(
             "Wrote snapshot {SnapshotKey} for dataset {DataSet} from normalised file {SourceKey}",
-            snapshotKey, definition.Name, sourceKey);
+            outputKey, fileSet.Definition.Name, source.Key);
 
-        return new SnapshotFile(definition)
+        return new SnapshotFile(fileSet.Definition)
         {
             RunId = fileSet.RunId,
-            Key = snapshotKey,
-            SourceKey = sourceKey,
-            Timestamp = timestamp,
+            Key = outputKey,
+            SourceTimestamp = source.Timestamp,
+            AppliedKeys = [source.Key],
             Created = true
         };
+    }
+
+    private static SnapshotFile Reused(NormalisedFileSet fileSet, TimestampedKey snapshot)
+        => new(fileSet.Definition)
+        {
+            RunId = fileSet.RunId,
+            Key = snapshot.Key,
+            SourceTimestamp = snapshot.Timestamp,
+            Created = false
+        };
+
+    private static DeltaMergeSource Source(IBlobStorageService storage, string key)
+        => new(key, token => storage.OpenReadAsync(key, token));
+
+    /// <summary>The dataset's newest snapshot, or null when it has none yet.</summary>
+    private static async Task<TimestampedKey?> LatestSnapshotAsync(
+        DataSetDefinition definition,
+        IBlobStorageService snapshots,
+        CancellationToken cancellationToken)
+    {
+        var existing = await snapshots.ListAsync(SnapshotFileNaming.DataSetPrefix(definition), cancellationToken);
+
+        return SnapshotFileNaming.OrderedByTimestamp(definition, existing.Select(o => o.Key)).LastOrDefault();
+    }
+
+    private abstract record SnapshotOutcome
+    {
+        public static readonly SnapshotOutcome None = new Skipped();
+        public static SnapshotOutcome Of(SnapshotFile file) => new Produced(file);
+
+        public sealed record Produced(SnapshotFile File) : SnapshotOutcome;
+        private sealed record Skipped : SnapshotOutcome;
     }
 
     /// <summary>The normalised keys the payload carries, falling back to listing the dataset's folder
@@ -127,45 +235,5 @@ public sealed class SnapshotStage(
         var objects = await normalised.ListAsync(SnapshotFileNaming.DataSetPrefix(fileSet.Definition), cancellationToken);
 
         return [.. objects.Select(o => o.Key)];
-    }
-
-    /// <summary>The newest existing snapshot for the dataset, when it was produced from
-    /// <paramref name="sourceKey"/>. Null when there is no snapshot yet or it is out of date.</summary>
-    private static async Task<string?> FindSnapshotForAsync(
-        DataSetDefinition definition,
-        string sourceKey,
-        IBlobStorageService snapshots,
-        CancellationToken cancellationToken)
-    {
-        var existing = await snapshots.ListAsync(SnapshotFileNaming.DataSetPrefix(definition), cancellationToken);
-        var latest = SnapshotFileNaming.LatestByTimestamp(definition, existing.Select(o => o.Key));
-
-        if (latest is null)
-        {
-            return null;
-        }
-
-        var metadata = await snapshots.GetMetadataAsync(latest, cancellationToken);
-
-        return metadata.UserMetadata.TryGetValue(EtlConstants.MetadataKeySnapshotSourceKey, out var recorded)
-            && string.Equals(recorded, sourceKey, StringComparison.Ordinal)
-                ? latest
-                : null;
-    }
-
-    private static async Task CopyAsync(
-        IBlobStorageService normalised,
-        string sourceKey,
-        IBlobStorageService snapshots,
-        string snapshotKey,
-        CancellationToken cancellationToken)
-    {
-        var metadata = new Dictionary<string, string> { { EtlConstants.MetadataKeySnapshotSourceKey, sourceKey } };
-
-        await using var source = await normalised.OpenReadAsync(sourceKey, cancellationToken);
-        await using var destination = await snapshots.OpenWriteAsync(
-            snapshotKey, SnapshotFileNaming.ParquetContentType, metadata, cancellationToken: cancellationToken);
-
-        await source.CopyToAsync(destination, cancellationToken);
     }
 }

--- a/src/KeeperData.Core/EtlPipeline/Storage/SnapshotFileNaming.cs
+++ b/src/KeeperData.Core/EtlPipeline/Storage/SnapshotFileNaming.cs
@@ -2,6 +2,9 @@ using KeeperData.Core.ETL.Impl;
 
 namespace KeeperData.Core.EtlPipeline.Storage;
 
+/// <summary>A dataset file paired with the source timestamp read from its name.</summary>
+public sealed record TimestampedKey(string Key, DateTimeOffset Timestamp);
+
 /// <summary>
 /// Naming convention for the files a dataset owns inside the <see cref="EtlPipelineFolders.Normalised"/>
 /// and <see cref="EtlPipelineFolders.Snapshots"/> folders. Keys are relative to those folders, because
@@ -21,7 +24,7 @@ public static class SnapshotFileNaming
         return $"{definition.Name}/";
     }
 
-    /// <summary>The key of a dataset's snapshot for a given ETL timestamp,
+    /// <summary>The key of a dataset's snapshot for the latest source timestamp it includes,
     /// e.g. <c>sam_cph_holdings/sam_cph_holdings_20260728112233.parquet</c>.</summary>
     public static string SnapshotKey(DataSetDefinition definition, DateTimeOffset timestamp)
     {
@@ -61,6 +64,35 @@ public static class SnapshotFileNaming
         }
 
         return latestKey;
+    }
+
+    /// <summary>
+    /// The dataset's keys ordered oldest first by the source timestamp in their names. Ordering comes
+    /// from the file name alone: object modified time, upload time and the ETL run time say nothing
+    /// about where a file sits in the sequence.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">A key carries no parsable timestamp, or two keys
+    /// carry the same one and there is no tie-break to choose between them.</exception>
+    public static IReadOnlyList<TimestampedKey> OrderedByTimestamp(DataSetDefinition definition, IEnumerable<string> keys)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentNullException.ThrowIfNull(keys);
+
+        var ordered = keys
+            .Select(key => new TimestampedKey(key, DataSetFileNaming.ExtractTimestamp(definition, key)))
+            .OrderBy(item => item.Timestamp)
+            .ToList();
+
+        var duplicate = ordered
+            .GroupBy(item => item.Timestamp)
+            .FirstOrDefault(group => group.Count() > 1);
+
+        return duplicate is null
+            ? ordered
+            : throw new InvalidOperationException(
+                $"Dataset '{definition.Name}' has {duplicate.Count()} files with source timestamp " +
+                $"{duplicate.Key.UtcDateTime.ToString(definition.DateTimePattern)} " +
+                $"({string.Join(", ", duplicate.Select(item => item.Key))}); there is no rule for which to apply first");
     }
 
     /// <summary>Non-throwing form of <see cref="DataSetFileNaming.ExtractTimestamp"/>.</summary>

--- a/src/KeeperData.Core/KeeperData.Core.csproj
+++ b/src/KeeperData.Core/KeeperData.Core.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
+    <PackageReference Include="Parquet.Net" Version="5.6.1" />
     <PackageReference Include="Polly.Core" Version="8.7.0" />
   </ItemGroup>
   

--- a/tests/KeeperData.Core.Tests.Unit/EtlPipeline/Harness/InMemoryEtlPipelineStorage.cs
+++ b/tests/KeeperData.Core.Tests.Unit/EtlPipeline/Harness/InMemoryEtlPipelineStorage.cs
@@ -25,7 +25,12 @@ public sealed class InMemoryBlobStorage(string container) : IBlobStorageService
     public void Put(string objectKey, string content, IReadOnlyDictionary<string, string>? metadata = null)
         => _objects[objectKey] = (System.Text.Encoding.UTF8.GetBytes(content), metadata?.ToDictionary() ?? []);
 
+    public void Put(string objectKey, byte[] content, IReadOnlyDictionary<string, string>? metadata = null)
+        => _objects[objectKey] = (content, metadata?.ToDictionary() ?? []);
+
     public string ContentOf(string objectKey) => System.Text.Encoding.UTF8.GetString(_objects[objectKey].Content);
+
+    public byte[] BytesOf(string objectKey) => _objects[objectKey].Content;
 
     public IReadOnlyDictionary<string, string> MetadataOf(string objectKey) => _objects[objectKey].Metadata;
 

--- a/tests/KeeperData.Core.Tests.Unit/EtlPipeline/Harness/ParquetFixture.cs
+++ b/tests/KeeperData.Core.Tests.Unit/EtlPipeline/Harness/ParquetFixture.cs
@@ -1,0 +1,70 @@
+using Parquet;
+using Parquet.Data;
+using Parquet.Schema;
+
+namespace KeeperData.Core.Tests.Unit.EtlPipeline.Harness;
+
+/// <summary>Builds and reads the small all-string Parquet files the snapshot tests trade in, written
+/// in the pipe-separated shape the source files arrive in so a fixture reads like the ticket's.
+///
+///   ParquetFixture.From("CHANGE_TYPE|CPH|HOLDING_NAME", "I|01/001/0001|Old Farm")
+/// </summary>
+public static class ParquetFixture
+{
+    public static byte[] From(string header, params string[] rows)
+    {
+        var columns = header.Split('|');
+        var values = columns.Select(_ => new List<string?>()).ToArray();
+
+        foreach (var row in rows)
+        {
+            var cells = row.Split('|');
+
+            for (var column = 0; column < columns.Length; column++)
+            {
+                values[column].Add(column < cells.Length ? cells[column] : null);
+            }
+        }
+
+        var fields = columns.Select(column => new DataField<string>(column)).ToArray();
+        var buffer = new MemoryStream();
+
+        using (var writer = ParquetWriter.CreateAsync(new ParquetSchema(fields), buffer).GetAwaiter().GetResult())
+        {
+            using var rowGroup = writer.CreateRowGroup();
+
+            for (var column = 0; column < fields.Length; column++)
+            {
+                rowGroup.WriteColumnAsync(new DataColumn(fields[column], values[column].ToArray())).GetAwaiter().GetResult();
+            }
+        }
+
+        return buffer.ToArray();
+    }
+
+    /// <summary>The file read back as pipe-separated lines, header first, so an assertion can be
+    /// written the same way as the fixture.</summary>
+    public static IReadOnlyList<string> ToLines(byte[] content)
+    {
+        using var reader = ParquetReader.CreateAsync(new MemoryStream(content)).GetAwaiter().GetResult();
+
+        var fields = reader.Schema.GetDataFields();
+        var lines = new List<string> { string.Join('|', fields.Select(field => field.Name)) };
+
+        for (var group = 0; group < reader.RowGroupCount; group++)
+        {
+            using var rowGroup = reader.OpenRowGroupReader(group);
+
+            var columns = fields
+                .Select(field => rowGroup.ReadColumnAsync(field).GetAwaiter().GetResult().Data)
+                .ToArray();
+
+            for (var row = 0; row < (columns.Length == 0 ? 0 : columns[0].Length); row++)
+            {
+                lines.Add(string.Join('|', columns.Select(column => column.GetValue(row)?.ToString() ?? string.Empty)));
+            }
+        }
+
+        return lines;
+    }
+}

--- a/tests/KeeperData.Core.Tests.Unit/EtlPipeline/ParquetDeltaMergeEngineTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/EtlPipeline/ParquetDeltaMergeEngineTests.cs
@@ -1,0 +1,170 @@
+using FluentAssertions;
+using KeeperData.Core.ETL.Impl;
+using KeeperData.Core.EtlPipeline.Snapshots;
+using KeeperData.Core.Tests.Unit.EtlPipeline.Harness;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace KeeperData.Core.Tests.Unit.EtlPipeline;
+
+/// <summary>The merge on its own: previous snapshot parquet + ordered delta parquets -> next snapshot
+/// parquet. No storage, no DuckDB, no Mongo.</summary>
+public class ParquetDeltaMergeEngineTests
+{
+    private const string DeltaHeader = "CHANGE_TYPE|CPH|HOLDING_NAME";
+    private const string SnapshotHeader = "CPH|HOLDING_NAME";
+
+    private static readonly DataSetDefinition SamCph =
+        new("sam_cph_holdings", "sam_cph_holdings_{0}", ["CPH"], ChangeType.HeaderName, [], IngestionMode: DataSetIngestionMode.Delta);
+
+    private readonly ParquetDeltaMergeEngine _engine = new(NullLogger<ParquetDeltaMergeEngine>.Instance);
+
+    private static DeltaMergeSource Source(string key, string header, params string[] rows)
+    {
+        var content = ParquetFixture.From(header, rows);
+
+        return new DeltaMergeSource(key, _ => Task.FromResult<Stream>(new MemoryStream(content)));
+    }
+
+    private async Task<(IReadOnlyList<string> Lines, DeltaMergeResult Result)> MergeAsync(
+        DeltaMergeSource? baseSnapshot,
+        params DeltaMergeSource[] deltas)
+    {
+        using var output = new MemoryStream();
+
+        var result = await _engine.MergeAsync(SamCph, baseSnapshot, deltas, output);
+
+        return (ParquetFixture.ToLines(output.ToArray()), result);
+    }
+
+    [Fact]
+    public async Task Folds_the_tickets_fixture_into_the_expected_snapshot()
+    {
+        var (lines, result) = await MergeAsync(
+            null,
+            Source("20251113", DeltaHeader, "I|01/001/0001|Old Farm", "I|01/001/0002|Keep Farm"),
+            Source("20251114", DeltaHeader, "U|01/001/0001|Updated Farm", "I|01/001/0003|New Farm"),
+            Source("20251115", DeltaHeader, "D|01/001/0002|Should Not Delete"));
+
+        lines.Should().Equal(
+            "CPH|HOLDING_NAME",
+            "01/001/0001|Updated Farm",
+            "01/001/0002|Keep Farm",
+            "01/001/0003|New Farm");
+
+        result.Should().BeEquivalentTo(new DeltaMergeResult
+        {
+            DeltasApplied = 3,
+            RowsUpserted = 4,
+            RowsIgnoredDeletes = 1,
+            RowsRejected = 0,
+            RowCount = 3
+        });
+    }
+
+    [Fact]
+    public async Task Folds_deltas_onto_an_existing_snapshot()
+    {
+        var (lines, _) = await MergeAsync(
+            Source("snapshot", SnapshotHeader, "01/001/0001|Old Farm"),
+            Source("delta", DeltaHeader, "U|01/001/0001|Updated Farm", "I|01/001/0002|New Farm"));
+
+        lines.Should().Equal(
+            "CPH|HOLDING_NAME",
+            "01/001/0001|Updated Farm",
+            "01/001/0002|New Farm");
+    }
+
+    [Fact]
+    public async Task Applies_deltas_in_the_order_given_so_the_last_writer_wins()
+    {
+        var (lines, _) = await MergeAsync(
+            null,
+            Source("first", DeltaHeader, "I|01/001/0001|First"),
+            Source("second", DeltaHeader, "U|01/001/0001|Second"),
+            Source("third", DeltaHeader, "U|01/001/0001|Third"));
+
+        lines.Should().Equal("CPH|HOLDING_NAME", "01/001/0001|Third");
+    }
+
+    [Fact]
+    public async Task A_later_row_in_the_same_delta_overrides_an_earlier_one()
+    {
+        var (lines, _) = await MergeAsync(
+            null,
+            Source("one", DeltaHeader, "I|01/001/0001|First", "U|01/001/0001|Second"));
+
+        lines.Should().Equal("CPH|HOLDING_NAME", "01/001/0001|Second");
+    }
+
+    [Fact]
+    public async Task Matches_rows_on_the_datasets_composite_primary_key()
+    {
+        var definition = SamCph with { PrimaryKeyHeaderNames = ["CPH", "HOLDING_NAME"] };
+
+        using var output = new MemoryStream();
+
+        await _engine.MergeAsync(
+            definition,
+            null,
+            [Source("one", DeltaHeader, "I|01/001/0001|Old Farm", "U|01/001/0001|Updated Farm")],
+            output);
+
+        // Different HOLDING_NAME, so with a composite key these are two rows rather than an update.
+        ParquetFixture.ToLines(output.ToArray()).Should().Equal(
+            "CPH|HOLDING_NAME",
+            "01/001/0001|Old Farm",
+            "01/001/0001|Updated Farm");
+    }
+
+    [Fact]
+    public async Task Counts_but_does_not_apply_delete_rows()
+    {
+        var (lines, result) = await MergeAsync(
+            Source("snapshot", SnapshotHeader, "01/001/0001|Keep Farm"),
+            Source("delta", DeltaHeader, "D|01/001/0001|Should Not Delete"));
+
+        lines.Should().Equal("CPH|HOLDING_NAME", "01/001/0001|Keep Farm");
+        result.RowsIgnoredDeletes.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Counts_but_does_not_apply_rows_with_an_unrecognised_change_type()
+    {
+        var (lines, result) = await MergeAsync(
+            null,
+            Source("delta", DeltaHeader, "I|01/001/0001|Keep Farm", "X|01/001/0002|Nonsense"));
+
+        lines.Should().Equal("CPH|HOLDING_NAME", "01/001/0001|Keep Farm");
+        result.RowsRejected.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Rejects_a_delta_missing_a_primary_key_column()
+    {
+        var merge = async () => await MergeAsync(null, Source("delta", "CHANGE_TYPE|HOLDING_NAME", "I|Old Farm"));
+
+        await merge.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*primary key column 'CPH'*");
+    }
+
+    [Fact]
+    public async Task Rejects_a_delta_missing_a_column_the_snapshot_carries()
+    {
+        var merge = async () => await MergeAsync(
+            Source("snapshot", SnapshotHeader, "01/001/0001|Old Farm"),
+            Source("delta", "CHANGE_TYPE|CPH", "I|01/001/0001"));
+
+        await merge.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*no column 'HOLDING_NAME'*");
+    }
+
+    [Fact]
+    public async Task Rewrites_the_snapshot_unchanged_when_there_are_no_deltas()
+    {
+        var (lines, result) = await MergeAsync(Source("snapshot", SnapshotHeader, "01/001/0001|Old Farm"));
+
+        lines.Should().Equal("CPH|HOLDING_NAME", "01/001/0001|Old Farm");
+        result.DeltasApplied.Should().Be(0);
+        result.RowCount.Should().Be(1);
+    }
+}

--- a/tests/KeeperData.Core.Tests.Unit/EtlPipeline/SnapshotFileNamingTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/EtlPipeline/SnapshotFileNamingTests.cs
@@ -7,7 +7,7 @@ namespace KeeperData.Core.Tests.Unit.EtlPipeline;
 public class SnapshotFileNamingTests
 {
     [Fact]
-    public void SnapshotKey_uses_the_clean_dataset_name_and_the_etl_timestamp()
+    public void SnapshotKey_uses_the_clean_dataset_name_and_the_source_timestamp()
     {
         var key = SnapshotFileNaming.SnapshotKey(
             StageRunner.Definition("sam_cph_holdings"),
@@ -44,5 +44,45 @@ public class SnapshotFileNamingTests
     public void LatestByTimestamp_returns_null_when_nothing_is_usable()
     {
         SnapshotFileNaming.LatestByTimestamp(StageRunner.Definition(), ["no-timestamp.parquet"]).Should().BeNull();
+    }
+
+    [Fact]
+    public void OrderedByTimestamp_orders_oldest_first_by_the_timestamp_in_the_name()
+    {
+        var ordered = SnapshotFileNaming.OrderedByTimestamp(
+            StageRunner.Definition("sam_cph_holdings"),
+            [
+                "sam_cph_holdings/sam_cph_holdings_20260715000000.parquet",
+                "sam_cph_holdings/sam_cph_holdings_20260701000000.parquet",
+                "sam_cph_holdings/sam_cph_holdings_20260710000000.parquet"
+            ]);
+
+        ordered.Select(item => item.Key).Should().Equal(
+            "sam_cph_holdings/sam_cph_holdings_20260701000000.parquet",
+            "sam_cph_holdings/sam_cph_holdings_20260710000000.parquet",
+            "sam_cph_holdings/sam_cph_holdings_20260715000000.parquet");
+    }
+
+    [Fact]
+    public void OrderedByTimestamp_rejects_a_key_carrying_no_timestamp()
+    {
+        var ordering = () => SnapshotFileNaming.OrderedByTimestamp(
+            StageRunner.Definition("sam_cph_holdings"), ["sam_cph_holdings/sam_cph_holdings.parquet"]);
+
+        ordering.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void OrderedByTimestamp_rejects_two_keys_sharing_a_timestamp()
+    {
+        var ordering = () => SnapshotFileNaming.OrderedByTimestamp(
+            StageRunner.Definition("sam_cph_holdings"),
+            [
+                "sam_cph_holdings/sam_cph_holdings_20260701000000.parquet",
+                "sam_cph_holdings/other_20260701000000.parquet"
+            ]);
+
+        ordering.Should().Throw<InvalidOperationException>()
+            .WithMessage("*no rule for which to apply first*");
     }
 }

--- a/tests/KeeperData.Core.Tests.Unit/EtlPipeline/SnapshotStageTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/EtlPipeline/SnapshotStageTests.cs
@@ -1,123 +1,193 @@
 using FluentAssertions;
 using KeeperData.Core.ETL.Impl;
 using KeeperData.Core.EtlPipeline.Payloads;
+using KeeperData.Core.EtlPipeline.Snapshots;
 using KeeperData.Core.EtlPipeline.Stages;
 using KeeperData.Core.EtlPipeline.Storage;
 using KeeperData.Core.Tests.Unit.EtlPipeline.Harness;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Time.Testing;
 
 namespace KeeperData.Core.Tests.Unit.EtlPipeline;
 
 /// <summary>Snapshot. Input: NormalisedFileSet. Output: SnapshotFile.
-/// Snapshot mode only: the latest normalised parquet is copied to snapshots/ under the dataset's
-/// clean name and a fresh ETL timestamp.</summary>
+/// Every normalised file newer than the latest snapshot is folded onto it, oldest first, and the
+/// result is written under the newest source timestamp applied.</summary>
 public class SnapshotStageTests
 {
-    private static readonly DataSetDefinition SamCph = StageRunner.Definition("sam_cph_holdings");
+    private const string Header = "CHANGE_TYPE|CPH|HOLDING_NAME";
+
+    private static readonly DataSetDefinition SamCph = Definition("sam_cph_holdings");
 
     private readonly InMemoryEtlPipelineStorage _storage = new();
-    private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(2026, 07, 28, 11, 22, 33, TimeSpan.Zero));
 
     private InMemoryBlobStorage Normalised => _storage.Folder(EtlPipelineFolders.Normalised);
     private InMemoryBlobStorage Snapshots => _storage.Folder(EtlPipelineFolders.Snapshots);
 
+    private static DataSetDefinition Definition(string name, DataSetIngestionMode mode = DataSetIngestionMode.Delta) =>
+        new(name, $"{name}_{{0}}", ["CPH"], ChangeType.HeaderName, [], IngestionMode: mode);
+
     private Task<List<SnapshotFile>> RunAsync(params NormalisedFileSet[] inputs) =>
-        StageRunner.RunAsync(new SnapshotStage(_storage, _timeProvider, NullLogger<SnapshotStage>.Instance), inputs);
+        StageRunner.RunAsync(
+            new SnapshotStage(
+                _storage,
+                new ParquetDeltaMergeEngine(NullLogger<ParquetDeltaMergeEngine>.Instance),
+                NullLogger<SnapshotStage>.Instance),
+            inputs);
+
+    private void PutNormalised(string dataSet, string timestamp, params string[] rows)
+        => Normalised.Put($"{dataSet}/{dataSet}_{timestamp}.parquet", ParquetFixture.From(Header, rows));
 
     [Fact]
-    public async Task Writes_a_snapshot_named_after_the_dataset_and_the_etl_timestamp()
+    public async Task Names_the_snapshot_after_the_newest_source_timestamp_applied_not_the_etl_run()
     {
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "rows");
+        PutNormalised("sam_cph_holdings", "20251113121333", "I|01/001/0001|Old Farm");
+        PutNormalised("sam_cph_holdings", "20251115121333", "U|01/001/0001|Updated Farm");
 
         var output = await RunAsync(new NormalisedFileSet(SamCph));
 
         output.Should().ContainSingle()
-            .Which.Key.Should().Be("sam_cph_holdings/sam_cph_holdings_20260728112233.parquet");
-        Snapshots.ContentOf("sam_cph_holdings/sam_cph_holdings_20260728112233.parquet").Should().Be("rows");
-    }
-
-    [Fact]
-    public async Task Snapshots_the_latest_normalised_file_by_filename_timestamp()
-    {
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "old");
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260715000000.parquet", "new");
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260710000000.parquet", "middle");
-
-        var output = await RunAsync(new NormalisedFileSet(SamCph));
-
-        output.Single().SourceKey.Should().Be("sam_cph_holdings/sam_cph_holdings_20260715000000.parquet");
-        Snapshots.ContentOf(output.Single().Key).Should().Be("new");
-    }
-
-    [Fact]
-    public async Task Prefers_the_files_carried_by_the_payload_over_listing_the_folder()
-    {
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "listed");
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260715000000.parquet", "supplied");
-
-        var output = await RunAsync(new NormalisedFileSet(SamCph)
-        {
-            Files = ["sam_cph_holdings/sam_cph_holdings_20260701000000.parquet"]
-        });
-
-        output.Single().SourceKey.Should().Be("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet");
-    }
-
-    [Fact]
-    public async Task Does_not_create_a_duplicate_snapshot_when_there_is_no_new_normalised_file()
-    {
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "rows");
-
-        var first = await RunAsync(new NormalisedFileSet(SamCph));
-
-        _timeProvider.Advance(TimeSpan.FromHours(1));
-
-        var second = await RunAsync(new NormalisedFileSet(SamCph));
-
-        second.Single().Key.Should().Be(first.Single().Key);
-        second.Single().Created.Should().BeFalse();
+            .Which.Key.Should().Be("sam_cph_holdings/sam_cph_holdings_20251115121333.parquet");
         Snapshots.Keys.Should().ContainSingle();
     }
 
     [Fact]
-    public async Task Creates_a_new_snapshot_when_a_newer_normalised_file_arrives()
+    public async Task Folds_every_normalised_file_when_no_snapshot_exists_yet()
     {
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "rows");
-        await RunAsync(new NormalisedFileSet(SamCph));
-
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260702000000.parquet", "more rows");
-        _timeProvider.Advance(TimeSpan.FromHours(1));
+        PutNormalised("sam_cph_holdings", "20251113121333", "I|01/001/0001|Old Farm", "I|01/001/0002|Keep Farm");
+        PutNormalised("sam_cph_holdings", "20251114121333", "U|01/001/0001|Updated Farm", "I|01/001/0003|New Farm");
+        PutNormalised("sam_cph_holdings", "20251115121333", "D|01/001/0002|Should Not Delete");
 
         var output = await RunAsync(new NormalisedFileSet(SamCph));
 
-        output.Single().Created.Should().BeTrue();
-        Snapshots.Keys.Should().HaveCount(2);
-        Snapshots.ContentOf(output.Single().Key).Should().Be("more rows");
+        ParquetFixture.ToLines(Snapshots.BytesOf(output.Single().Key)).Should().Equal(
+            "CPH|HOLDING_NAME",
+            "01/001/0001|Updated Farm",
+            "01/001/0002|Keep Farm",
+            "01/001/0003|New Farm");
+    }
+
+    [Fact]
+    public async Task Applies_only_the_files_newer_than_the_latest_snapshot()
+    {
+        PutNormalised("sam_cph_holdings", "20251113121333", "I|01/001/0001|Old Farm");
+
+        var first = await RunAsync(new NormalisedFileSet(SamCph));
+
+        PutNormalised("sam_cph_holdings", "20251114121333", "U|01/001/0001|Updated Farm");
+
+        var second = await RunAsync(new NormalisedFileSet(SamCph));
+
+        first.Single().AppliedKeys.Should().Equal("sam_cph_holdings/sam_cph_holdings_20251113121333.parquet");
+        second.Single().AppliedKeys.Should().Equal("sam_cph_holdings/sam_cph_holdings_20251114121333.parquet");
+        ParquetFixture.ToLines(Snapshots.BytesOf(second.Single().Key)).Should().Equal(
+            "CPH|HOLDING_NAME",
+            "01/001/0001|Updated Farm");
+    }
+
+    [Fact]
+    public async Task Drops_the_change_type_column_from_the_snapshot()
+    {
+        PutNormalised("sam_cph_holdings", "20251113121333", "I|01/001/0001|Old Farm");
+
+        var output = await RunAsync(new NormalisedFileSet(SamCph));
+
+        ParquetFixture.ToLines(Snapshots.BytesOf(output.Single().Key))[0].Should().Be("CPH|HOLDING_NAME");
+    }
+
+    [Fact]
+    public async Task Reuses_the_existing_snapshot_when_nothing_newer_has_arrived()
+    {
+        PutNormalised("sam_cph_holdings", "20251113121333", "I|01/001/0001|Old Farm");
+
+        var first = await RunAsync(new NormalisedFileSet(SamCph));
+        var second = await RunAsync(new NormalisedFileSet(SamCph));
+
+        second.Single().Key.Should().Be(first.Single().Key);
+        second.Single().Created.Should().BeFalse();
+        second.Single().AppliedKeys.Should().BeEmpty();
+        Snapshots.Keys.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Retains_older_snapshots_rather_than_replacing_them()
+    {
+        PutNormalised("sam_cph_holdings", "20251113121333", "I|01/001/0001|Old Farm");
+        await RunAsync(new NormalisedFileSet(SamCph));
+
+        PutNormalised("sam_cph_holdings", "20251114121333", "U|01/001/0001|Updated Farm");
+        await RunAsync(new NormalisedFileSet(SamCph));
+
+        Snapshots.Keys.Should().BeEquivalentTo(
+            "sam_cph_holdings/sam_cph_holdings_20251113121333.parquet",
+            "sam_cph_holdings/sam_cph_holdings_20251114121333.parquet");
     }
 
     [Fact]
     public async Task Never_overwrites_an_existing_snapshot_file()
     {
-        var key = "sam_cph_holdings/sam_cph_holdings_20260728112233.parquet";
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "rows");
+        var key = "sam_cph_holdings/sam_cph_holdings_20251113121333.parquet";
+        PutNormalised("sam_cph_holdings", "20251113121333", "I|01/001/0001|Old Farm");
         Snapshots.Put(key, "written by someone else");
 
         var output = await RunAsync(new NormalisedFileSet(SamCph));
 
-        output.Should().BeEmpty();
+        output.Single().Created.Should().BeFalse();
         Snapshots.ContentOf(key).Should().Be("written by someone else");
     }
 
     [Fact]
-    public async Task Records_the_normalised_file_the_snapshot_came_from()
+    public async Task Reports_what_the_merge_did()
     {
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "rows");
+        PutNormalised("sam_cph_holdings", "20251113121333", "I|01/001/0001|Old Farm", "I|01/001/0002|Keep Farm");
+        PutNormalised("sam_cph_holdings", "20251115121333", "D|01/001/0002|Should Not Delete");
 
         var output = await RunAsync(new NormalisedFileSet(SamCph));
 
-        Snapshots.MetadataOf(output.Single().Key)[EtlConstants.MetadataKeySnapshotSourceKey]
-            .Should().Be("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet");
+        output.Single().Should().BeEquivalentTo(new
+        {
+            SourceTimestamp = new DateTimeOffset(2025, 11, 15, 12, 13, 33, TimeSpan.Zero),
+            Created = true,
+            RowCount = 2L,
+            RowsUpserted = 2L,
+            RowsIgnoredDeletes = 1L
+        });
+    }
+
+    [Fact]
+    public async Task Fails_the_import_when_a_normalised_file_carries_no_source_timestamp()
+    {
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings.parquet", ParquetFixture.From(Header, "I|01/001/0001|Old Farm"));
+
+        var run = async () => await RunAsync(new NormalisedFileSet(SamCph));
+
+        await run.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*sam_cph_holdings.parquet*");
+    }
+
+    [Fact]
+    public async Task Fails_the_import_when_two_normalised_files_share_a_source_timestamp()
+    {
+        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20251113121333.parquet", ParquetFixture.From(Header, "I|01/001/0001|Old Farm"));
+        Normalised.Put("sam_cph_holdings/other_20251113121333.parquet", ParquetFixture.From(Header, "I|01/001/0002|Keep Farm"));
+
+        var run = async () => await RunAsync(new NormalisedFileSet(SamCph));
+
+        await run.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*no rule for which to apply first*");
+    }
+
+    [Fact]
+    public async Task Prefers_the_files_carried_by_the_payload_over_listing_the_folder()
+    {
+        PutNormalised("sam_cph_holdings", "20251113121333", "I|01/001/0001|Old Farm");
+        PutNormalised("sam_cph_holdings", "20251114121333", "U|01/001/0001|Updated Farm");
+
+        var output = await RunAsync(new NormalisedFileSet(SamCph)
+        {
+            Files = ["sam_cph_holdings/sam_cph_holdings_20251113121333.parquet"]
+        });
+
+        output.Single().Key.Should().Be("sam_cph_holdings/sam_cph_holdings_20251113121333.parquet");
     }
 
     [Fact]
@@ -130,31 +200,6 @@ public class SnapshotStageTests
     }
 
     [Fact]
-    public async Task Ignores_normalised_files_whose_name_carries_no_timestamp()
-    {
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings.parquet", "unnamed");
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "rows");
-
-        var output = await RunAsync(new NormalisedFileSet(SamCph));
-
-        output.Single().SourceKey.Should().Be("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet");
-    }
-
-    [Fact]
-    public async Task Produces_one_snapshot_per_dataset()
-    {
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "sam");
-        Normalised.Put("cts_keeper/cts_keeper_20260701000000.parquet", "cts");
-
-        var output = await RunAsync(
-            new NormalisedFileSet(SamCph),
-            new NormalisedFileSet(StageRunner.Definition("cts_keeper")));
-
-        output.Select(o => o.Definition.Name).Should().Equal("sam_cph_holdings", "cts_keeper");
-        Snapshots.Keys.Should().HaveCount(2);
-    }
-
-    [Fact]
     public async Task Produces_nothing_for_an_empty_input()
     {
         var output = await RunAsync();
@@ -163,24 +208,29 @@ public class SnapshotStageTests
     }
 
     [Fact]
-    public async Task The_latest_snapshot_is_the_one_with_the_newest_etl_timestamp()
+    public async Task Produces_one_snapshot_per_dataset()
     {
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260701000000.parquet", "first");
-        var first = await RunAsync(new NormalisedFileSet(SamCph));
+        PutNormalised("sam_cph_holdings", "20251113121333", "I|01/001/0001|Old Farm");
+        PutNormalised("cts_keeper", "20251113121333", "I|02/002/0002|Other Farm");
 
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260702000000.parquet", "second");
-        _timeProvider.Advance(TimeSpan.FromHours(1));
-        var second = await RunAsync(new NormalisedFileSet(SamCph));
+        var output = await RunAsync(
+            new NormalisedFileSet(SamCph),
+            new NormalisedFileSet(Definition("cts_keeper")));
 
-        Normalised.Put("sam_cph_holdings/sam_cph_holdings_20260703000000.parquet", "third");
-        _timeProvider.Advance(TimeSpan.FromHours(1));
-        var third = await RunAsync(new NormalisedFileSet(SamCph));
+        output.Select(o => o.Definition.Name).Should().Equal("sam_cph_holdings", "cts_keeper");
+        Snapshots.Keys.Should().HaveCount(2);
+    }
 
-        var allKeys = Snapshots.Keys.ToList();
-        allKeys.Should().HaveCount(3);
+    [Fact]
+    public async Task A_snapshot_mode_dataset_copies_its_latest_normalised_file_unchanged()
+    {
+        var definition = Definition("sam_showground", DataSetIngestionMode.Snapshot);
+        Normalised.Put("sam_showground/sam_showground_20251113121333.parquet", "older");
+        Normalised.Put("sam_showground/sam_showground_20251115121333.parquet", "latest");
 
-        var latest = SnapshotFileNaming.LatestByTimestamp(SamCph, allKeys);
+        var output = await RunAsync(new NormalisedFileSet(definition));
 
-        latest.Should().Be(third.Single().Key);
+        output.Single().Key.Should().Be("sam_showground/sam_showground_20251115121333.parquet");
+        Snapshots.ContentOf(output.Single().Key).Should().Be("latest");
     }
 }


### PR DESCRIPTION
- Add DataSetIngestionMode (Snapshot/Delta) to DataSetDefinition
- Implement ParquetDeltaMergeEngine for delta folding and upserts
- SnapshotStage now merges deltas, never overwrites snapshots
- Enforce unique, parseable timestamps for input files
- Remove MetadataKeySnapshotSourceKey; use filename timestamp for resume
- Add Parquet.Net dependency and in-memory Parquet test fixtures
- Expand and update tests for delta logic and error cases
- Refactor code and comments for clarity and maintainability