### PR TITLE
Update to Parquet.Net 6.0.1 and refactor for new API

### DIFF
--- a/src/KeeperData.Core/EtlPipeline/Snapshots/MergeState.cs
+++ b/src/KeeperData.Core/EtlPipeline/Snapshots/MergeState.cs
@@ -1,6 +1,5 @@
 using KeeperData.Core.ETL.Impl;
 using Parquet;
-using Parquet.Data;
 using Parquet.Schema;
 
 namespace KeeperData.Core.EtlPipeline.Snapshots;
@@ -11,7 +10,7 @@ public sealed partial class ParquetDeltaMergeEngine
     private sealed class MergeState(DataSetDefinition definition)
     {
         private readonly Dictionary<string, int> _indexByKey = new(StringComparer.Ordinal);
-        private readonly List<object?[]> _rows = [];
+        private readonly List<string?[]> _rows = [];
 
         private DataField[]? _fields;
 
@@ -39,7 +38,7 @@ public sealed partial class ParquetDeltaMergeEngine
 
             foreach (var row in table.Rows)
             {
-                var changeType = changeTypeIndex < 0 ? ChangeType.Insert : Text(row[changeTypeIndex]);
+                var changeType = changeTypeIndex < 0 ? ChangeType.Insert : row[changeTypeIndex];
 
                 switch (changeType)
                 {
@@ -68,27 +67,26 @@ public sealed partial class ParquetDeltaMergeEngine
             var fields = _fields
                 ?? throw new InvalidOperationException($"Nothing to write for dataset '{definition.Name}': no file supplied a schema");
 
-            using var writer = await ParquetWriter.CreateAsync(new ParquetSchema(fields), output, cancellationToken: cancellationToken);
+            await using var writer = await ParquetWriter.CreateAsync(new ParquetSchema(fields), output, cancellationToken: cancellationToken);
             using var rowGroup = writer.CreateRowGroup();
 
             for (var column = 0; column < fields.Length; column++)
             {
-                var values = Array.CreateInstance(fields[column].ClrNullableIfHasNullsType, _rows.Count);
-
+                var values = new string?[_rows.Count];
                 for (var row = 0; row < _rows.Count; row++)
                 {
-                    values.SetValue(_rows[row][column], row);
+                    values[row] = _rows[row][column];
                 }
 
-                await rowGroup.WriteColumnAsync(new DataColumn(fields[column], values), cancellationToken);
+                await rowGroup.WriteAsync(fields[column], (IReadOnlyCollection<string?>)values);
             }
         }
 
         /// <summary>The row reduced to the output columns, in output column order.</summary>
-        private object?[] Project(ParquetTable table, object?[] row, string key)
+        private string?[] Project(ParquetTable table, string?[] row, string key)
         {
             var fields = _fields!;
-            var projected = new object?[fields.Length];
+            var projected = new string?[fields.Length];
 
             for (var column = 0; column < fields.Length; column++)
             {
@@ -106,7 +104,7 @@ public sealed partial class ParquetDeltaMergeEngine
             return projected;
         }
 
-        private void Upsert(object?[] row, string compositeKey)
+        private void Upsert(string?[] row, string compositeKey)
         {
             if (_indexByKey.TryGetValue(compositeKey, out var existing))
             {
@@ -118,7 +116,7 @@ public sealed partial class ParquetDeltaMergeEngine
             _rows.Add(row);
         }
 
-        private string CompositeKey(ParquetTable table, object?[] row, string key)
+        private string CompositeKey(ParquetTable table, string?[] row, string key)
         {
             var parts = definition.PrimaryKeyHeaderNames.Select(name =>
             {
@@ -127,7 +125,7 @@ public sealed partial class ParquetDeltaMergeEngine
                 return index < 0
                     ? throw new InvalidOperationException(
                         $"'{key}' has no primary key column '{name}' for dataset '{definition.Name}'")
-                    : Text(row[index]);
+                    : row[index] ?? string.Empty;
             });
 
             return string.Join(EtlConstants.CompositeKeyDelimiter, parts);
@@ -135,7 +133,5 @@ public sealed partial class ParquetDeltaMergeEngine
 
         private bool IsChangeType(string name)
             => string.Equals(name, definition.ChangeTypeHeaderName, StringComparison.OrdinalIgnoreCase);
-
-        private static string Text(object? value) => value?.ToString() ?? string.Empty;
     }
 }

--- a/src/KeeperData.Core/EtlPipeline/Snapshots/ParquetTable.cs
+++ b/src/KeeperData.Core/EtlPipeline/Snapshots/ParquetTable.cs
@@ -11,7 +11,7 @@ public sealed partial class ParquetDeltaMergeEngine
     {
         private readonly Dictionary<string, int> _indexByName = new(StringComparer.OrdinalIgnoreCase);
 
-        private ParquetTable(DataField[] fields, List<object?[]> rows)
+        private ParquetTable(DataField[] fields, List<string?[]> rows)
         {
             Fields = fields;
             Rows = rows;
@@ -24,14 +24,14 @@ public sealed partial class ParquetDeltaMergeEngine
 
         public DataField[] Fields { get; }
 
-        public List<object?[]> Rows { get; }
+        public List<string?[]> Rows { get; }
 
         public int IndexOf(string name) => _indexByName.TryGetValue(name, out var index) ? index : -1;
 
         public static async Task<ParquetTable> ReadAsync(Stream stream, string key, CancellationToken cancellationToken)
         {
             await using var seekable = await AsSeekableAsync(stream, cancellationToken);
-            using var reader = await ParquetReader.CreateAsync(seekable, cancellationToken: cancellationToken);
+            await using var reader = await ParquetReader.CreateAsync(seekable, cancellationToken: cancellationToken);
 
             var fields = reader.Schema.GetDataFields();
             var rows = await ReadRowsAsync(reader, fields, cancellationToken);
@@ -41,9 +41,9 @@ public sealed partial class ParquetDeltaMergeEngine
                 : new ParquetTable(fields, rows);
         }
 
-        private static async Task<List<object?[]>> ReadRowsAsync(ParquetReader reader, DataField[] fields, CancellationToken cancellationToken)
+        private static async Task<List<string?[]>> ReadRowsAsync(ParquetReader reader, DataField[] fields, CancellationToken cancellationToken)
         {
-            var rows = new List<object?[]>();
+            var rows = new List<string?[]>();
 
             for (var group = 0; group < reader.RowGroupCount; group++)
             {
@@ -55,29 +55,32 @@ public sealed partial class ParquetDeltaMergeEngine
             return rows;
         }
 
-        private static async Task<Array[]> ReadColumnsAsync(ParquetRowGroupReader rowGroup, DataField[] fields, CancellationToken cancellationToken)
+        private static async Task<string[][]> ReadColumnsAsync(ParquetRowGroupReader rowGroup, DataField[] fields, CancellationToken cancellationToken)
         {
-            var columns = new Array[fields.Length];
+            var rowCount = (int)rowGroup.RowCount;
+            var columns = new string[fields.Length][];
 
             for (var column = 0; column < fields.Length; column++)
             {
-                columns[column] = (await rowGroup.ReadColumnAsync(fields[column], cancellationToken)).Data;
+                var buf = new string[rowCount];
+                await rowGroup.ReadAsync(fields[column], buf.AsMemory(), cancellationToken: cancellationToken);
+                columns[column] = buf;
             }
 
             return columns;
         }
 
-        private static void AppendRows(List<object?[]> rows, Array[] columns, int fieldCount)
+        private static void AppendRows(List<string?[]> rows, string[][] columns, int fieldCount)
         {
             var count = columns.Length == 0 ? 0 : columns[0].Length;
 
             for (var row = 0; row < count; row++)
             {
-                var values = new object?[fieldCount];
+                var values = new string?[fieldCount];
 
                 for (var column = 0; column < fieldCount; column++)
                 {
-                    values[column] = columns[column].GetValue(row);
+                    values[column] = columns[column][row];
                 }
 
                 rows.Add(values);

--- a/src/KeeperData.Core/KeeperData.Core.csproj
+++ b/src/KeeperData.Core/KeeperData.Core.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
-    <PackageReference Include="Parquet.Net" Version="5.6.1" />
+    <PackageReference Include="Parquet.Net" Version="6.0.1" />
     <PackageReference Include="Polly.Core" Version="8.7.0" />
   </ItemGroup>
   

--- a/tests/KeeperData.Core.Tests.Unit/EtlPipeline/Harness/ParquetFixture.cs
+++ b/tests/KeeperData.Core.Tests.Unit/EtlPipeline/Harness/ParquetFixture.cs
@@ -1,5 +1,4 @@
 using Parquet;
-using Parquet.Data;
 using Parquet.Schema;
 
 namespace KeeperData.Core.Tests.Unit.EtlPipeline.Harness;
@@ -29,24 +28,38 @@ public static class ParquetFixture
         var fields = columns.Select(column => new DataField<string>(column)).ToArray();
         var buffer = new MemoryStream();
 
-        using (var writer = ParquetWriter.CreateAsync(new ParquetSchema(fields), buffer).GetAwaiter().GetResult())
-        {
-            using var rowGroup = writer.CreateRowGroup();
-
-            for (var column = 0; column < fields.Length; column++)
-            {
-                rowGroup.WriteColumnAsync(new DataColumn(fields[column], values[column].ToArray())).GetAwaiter().GetResult();
-            }
-        }
+        WriteParquet(fields, values, buffer);
 
         return buffer.ToArray();
+    }
+
+    private static void WriteParquet(DataField<string>[] fields, List<string?>[] values, MemoryStream buffer)
+    {
+        var task = WriteParquetAsync(fields, values, buffer);
+        task.GetAwaiter().GetResult();
+    }
+
+    private static async Task WriteParquetAsync(DataField<string>[] fields, List<string?>[] values, MemoryStream buffer)
+    {
+        await using var writer = await ParquetWriter.CreateAsync(new ParquetSchema(fields), buffer);
+        using var rowGroup = writer.CreateRowGroup();
+
+        for (var column = 0; column < fields.Length; column++)
+        {
+            await rowGroup.WriteAsync(fields[column], (IReadOnlyCollection<string?>)values[column]);
+        }
     }
 
     /// <summary>The file read back as pipe-separated lines, header first, so an assertion can be
     /// written the same way as the fixture.</summary>
     public static IReadOnlyList<string> ToLines(byte[] content)
     {
-        using var reader = ParquetReader.CreateAsync(new MemoryStream(content)).GetAwaiter().GetResult();
+        return ReadLinesAsync(content).GetAwaiter().GetResult();
+    }
+
+    private static async Task<IReadOnlyList<string>> ReadLinesAsync(byte[] content)
+    {
+        await using var reader = await ParquetReader.CreateAsync(new MemoryStream(content));
 
         var fields = reader.Schema.GetDataFields();
         var lines = new List<string> { string.Join('|', fields.Select(field => field.Name)) };
@@ -55,13 +68,19 @@ public static class ParquetFixture
         {
             using var rowGroup = reader.OpenRowGroupReader(group);
 
-            var columns = fields
-                .Select(field => rowGroup.ReadColumnAsync(field).GetAwaiter().GetResult().Data)
-                .ToArray();
+            var rowCount = (int)rowGroup.RowCount;
+            var columns = new string[fields.Length][];
 
-            for (var row = 0; row < (columns.Length == 0 ? 0 : columns[0].Length); row++)
+            for (var col = 0; col < fields.Length; col++)
             {
-                lines.Add(string.Join('|', columns.Select(column => column.GetValue(row)?.ToString() ?? string.Empty)));
+                var buf = new string[rowCount];
+                await rowGroup.ReadAsync(fields[col], buf.AsMemory());
+                columns[col] = buf;
+            }
+
+            for (var row = 0; row < rowCount; row++)
+            {
+                lines.Add(string.Join('|', columns.Select(column => column?[row] ?? string.Empty)));
             }
         }
 


### PR DESCRIPTION
Migrated from Parquet.Net 5.6.1 to 6.0.1, updating all read/write logic to use the new strongly-typed, columnar APIs. Refactored internal data structures to use string?[] and string[][] for rows and columns. Updated MergeState, ParquetTable, and ParquetFixture to match the new API, including async patterns and removal of obsolete helpers. All test utilities and related methods were adapted for compatibility.