### PR TITLE
Add DuckDB staging load stage and presigned URL API

### DIFF
--- a/src/KeeperData.Bridge/Controllers/FileBasedStagingController.cs
+++ b/src/KeeperData.Bridge/Controllers/FileBasedStagingController.cs
@@ -1,0 +1,127 @@
+using System.Diagnostics.CodeAnalysis;
+using KeeperData.Bridge.Extensions;
+using KeeperData.Core.EtlPipeline.Storage;
+using KeeperData.Core.Storage;
+using KeeperData.Core.Storage.Dtos;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KeeperData.Bridge.Controllers;
+
+/// <summary>Download access to the DuckDB staging databases the load stage produces.
+/// A prototype stand-in for the presigned-URI API, in the same shape as the SQLite endpoint.</summary>
+[ApiController]
+[Route("api/etl/file-based/staging")]
+[ExcludeFromCodeCoverage(Justification = "API controller - covered by component/integration tests.")]
+public class FileBasedStagingController(
+    IBlobStorageServiceFactory blobStorageServiceFactory,
+    ILogger<FileBasedStagingController> logger) : ControllerBase
+{
+    private const string StagingPrefix = $"{EtlPipelineFolders.Staging}/";
+    private static readonly TimeSpan DefaultPresignedUrlExpiry = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Returns a presigned download URL for the latest DuckDB staging database.
+    /// The URL is valid for 1 hour by default.
+    /// </summary>
+    /// <param name="expiresInMinutes">Optional expiry in minutes (default: 60, max: 10080 / 7 days)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    [HttpGet("duckdb/latest")]
+    [ProducesResponseType(typeof(StagingDatabaseLatestResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(StagingDatabaseErrorResponse), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(StagingDatabaseErrorResponse), StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetLatestDuckDbUrl(
+        [FromQuery] int? expiresInMinutes = null,
+        CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Received request for latest DuckDB staging presigned URL");
+
+        try
+        {
+            var storageService = blobStorageServiceFactory.GetSourceInternal();
+            var objects = await storageService.ListAsync(StagingPrefix, cancellationToken);
+
+            var latest = objects.GetLatest();
+
+            if (latest is null) return ObjectNotFound;
+
+            var expiry = expiresInMinutes.HasValue
+                ? TimeSpan.FromMinutes(Math.Clamp(expiresInMinutes.Value, 1, 10080))
+                : DefaultPresignedUrlExpiry;
+
+            var presignedUrl = storageService.GeneratePresignedUrl(latest.Key, expiry);
+
+            logger.LogInformation("Generated presigned URL for {Key} (expires in {ExpiryMinutes} min)",
+                latest.Key, expiry.TotalMinutes);
+
+            return PresignedUrlReady(latest, presignedUrl, expiry);
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogWarning("Get latest DuckDB staging request was cancelled");
+            return RequestCancelled();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unexpected error getting latest DuckDB staging presigned URL");
+            return PresignedUrlFailed();
+        }
+    }
+
+    private OkObjectResult PresignedUrlReady(StorageObjectInfo latest, string presignedUrl, TimeSpan expiry)
+        => Ok(new StagingDatabaseLatestResponse
+        {
+            ObjectKey = latest.Key,
+            DownloadUrl = presignedUrl,
+            Size = latest.Size,
+            LastModified = latest.LastModified,
+            ExpiresAt = DateTime.UtcNow.Add(expiry)
+        });
+
+    private ObjectResult RequestCancelled()
+        => StatusCode(499, new StagingDatabaseErrorResponse
+        {
+            Message = "Request was cancelled.",
+            Timestamp = DateTime.UtcNow
+        });
+
+    private ObjectResult PresignedUrlFailed()
+        => StatusCode(StatusCodes.Status500InternalServerError, new StagingDatabaseErrorResponse
+        {
+            Message = "An unexpected error occurred while generating the download URL.",
+            Timestamp = DateTime.UtcNow
+        });
+
+    private NotFoundObjectResult ObjectNotFound
+    {
+        get
+        {
+            logger.LogWarning("No DuckDB staging files found in {Prefix}", StagingPrefix);
+            return NotFound(new StagingDatabaseErrorResponse
+            {
+                Message = "No DuckDB staging databases found. Run the file-based ETL pipeline first.",
+                Timestamp = DateTime.UtcNow
+            });
+        }
+    }
+}
+
+#region Response DTOs
+
+[ExcludeFromCodeCoverage(Justification = "DTO record - no logic to test.")]
+public record StagingDatabaseLatestResponse
+{
+    public required string ObjectKey { get; init; }
+    public required string DownloadUrl { get; init; }
+    public long Size { get; init; }
+    public DateTimeOffset LastModified { get; init; }
+    public DateTime ExpiresAt { get; init; }
+}
+
+[ExcludeFromCodeCoverage(Justification = "DTO record - no logic to test.")]
+public record StagingDatabaseErrorResponse
+{
+    public required string Message { get; init; }
+    public DateTime Timestamp { get; init; }
+}
+
+#endregion

--- a/src/KeeperData.Bridge/Extensions/StorageObjectInfoExtensions.cs
+++ b/src/KeeperData.Bridge/Extensions/StorageObjectInfoExtensions.cs
@@ -1,0 +1,14 @@
+using KeeperData.Core.EtlPipeline.Storage;
+using KeeperData.Core.Storage.Dtos;
+
+namespace KeeperData.Bridge.Extensions
+{
+    public static class StorageObjectInfoExtensions
+    {
+        public static StorageObjectInfo? GetLatest(this IReadOnlyList<StorageObjectInfo> objects) => 
+            objects.Where(o => o.Key.Contains(StagingFileNaming.DatabasePrefix, StringComparison.Ordinal) 
+            && o.Key.EndsWith(StagingFileNaming.DatabaseExtension, StringComparison.OrdinalIgnoreCase))
+            .OrderByDescending(o => o.Key, StringComparer.Ordinal)
+            .FirstOrDefault();
+    }
+}

--- a/src/KeeperData.Core/EtlPipeline/EtlPipelineFactory.cs
+++ b/src/KeeperData.Core/EtlPipeline/EtlPipelineFactory.cs
@@ -10,7 +10,8 @@ namespace KeeperData.Core.EtlPipeline;
 public sealed class EtlPipelineFactory(
     IExternalCatalogueServiceFactory catalogueFactory,
     DecryptStage decryptStage,
-    SnapshotStage snapshotStage) : IEtlPipelineFactory
+    SnapshotStage snapshotStage,
+    LoadDuckDbStage loadDuckDbStage) : IEtlPipelineFactory
 {
     public PipelineDefinition Create()
         => PipelineBuilder
@@ -19,6 +20,6 @@ public sealed class EtlPipelineFactory(
             .Decrypt(decryptStage)    // -> RawFileSet        (raw/)
             .Normalise()              // -> NormalisedFileSet (normalised/*.parquet)
             .Snapshot(snapshotStage)  // -> SnapshotFile      (snapshots/*.parquet)
-            .LoadDuckDb()             // -> StagingDatabase   (staging/*.duckdb)
+            .LoadDuckDb(loadDuckDbStage) // -> StagingDatabase (staging/*.duckdb)
             .Build();
 }

--- a/src/KeeperData.Core/EtlPipeline/Fluent/PipelineExtensions.cs
+++ b/src/KeeperData.Core/EtlPipeline/Fluent/PipelineExtensions.cs
@@ -20,6 +20,6 @@ public static class PipelineExtensions
     public static PipelineBuilder<SnapshotFile> Snapshot(this PipelineBuilder<NormalisedFileSet> builder, SnapshotStage stage)
         => builder.Then(stage);
 
-    public static PipelineBuilder<StagingDatabase> LoadDuckDb(this PipelineBuilder<SnapshotFile> builder)
-        => builder.Then(new LoadDuckDbStage());
+    public static PipelineBuilder<StagingDatabase> LoadDuckDb(this PipelineBuilder<SnapshotFile> builder, LoadDuckDbStage stage)
+        => builder.Then(stage);
 }

--- a/src/KeeperData.Core/EtlPipeline/Payloads/StagingDatabase.cs
+++ b/src/KeeperData.Core/EtlPipeline/Payloads/StagingDatabase.cs
@@ -1,3 +1,5 @@
+using KeeperData.Core.EtlPipeline.Staging;
+
 namespace KeeperData.Core.EtlPipeline.Payloads;
 
 /// <summary>The single DuckDB staging database in staging/. Final output of the pipeline.</summary>
@@ -5,10 +7,14 @@ public sealed record StagingDatabase
 {
     public Guid RunId { get; init; }
 
-    /* Delete this region once the previous stage provides these */
-    #region TEMP - PlaceholderInputs
+    public string Key { get; init; } = string.Empty;
 
-    public string DatabaseKey { get; init; } = string.Empty;
+    /// <summary>The newest snapshot source timestamp the database holds, carried through from the
+    /// snapshots loaded. Not the time the ETL ran.</summary>
+    public DateTimeOffset SourceTimestamp { get; init; }
 
-    #endregion
+    public IReadOnlyList<StagingTable> Tables { get; init; } = [];
+
+    /// <summary>False when the database for these snapshots already existed and was reused.</summary>
+    public bool Created { get; init; }
 }

--- a/src/KeeperData.Core/EtlPipeline/Setup/ServiceCollectionExtensions.cs
+++ b/src/KeeperData.Core/EtlPipeline/Setup/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ public static class ServiceCollectionExtensions
 
         services.AddScoped<DecryptStage>();
         services.AddScoped<SnapshotStage>();
+        services.AddScoped<LoadDuckDbStage>();
 
         return services;
     }

--- a/src/KeeperData.Core/EtlPipeline/Stages/LoadDuckDbStage.cs
+++ b/src/KeeperData.Core/EtlPipeline/Stages/LoadDuckDbStage.cs
@@ -1,15 +1,129 @@
+using System.Runtime.CompilerServices;
 using KeeperData.Core.EtlPipeline.Payloads;
+using KeeperData.Core.EtlPipeline.Staging;
+using KeeperData.Core.EtlPipeline.Storage;
 using KeeperData.Core.Pipeline;
+using KeeperData.Core.Storage;
+using Microsoft.Extensions.Logging;
 
 namespace KeeperData.Core.EtlPipeline.Stages;
 
 /// <summary>Loads every dataset snapshot as a table into the single DuckDB staging database.
 /// All snapshots -> one database. Materialises: staging/.
-/// STUB - passes through. The owner adds the DuckDB writer dependency and implements AggregateAsync.</summary>
-public sealed class LoadDuckDbStage : AggregateStage<SnapshotFile, StagingDatabase>
+///
+/// The database is named with the newest source timestamp of the snapshots it holds, so the whole
+/// chain - normalised, snapshot, staging - carries one timestamp end to end, and a re-run over the
+/// same snapshots resolves to the same key and does nothing.
+///
+/// It is built in a temporary directory and uploaded only once every table has been written and its
+/// row count verified against its Parquet source, so a failure part way through leaves nothing in
+/// staging/ rather than a partial database.</summary>
+public sealed class LoadDuckDbStage(
+    IEtlPipelineStorageProvider storageProvider,
+    IStagingDatabaseWriter databaseWriter,
+    ILogger<LoadDuckDbStage> logger) : IStage<SnapshotFile, StagingDatabase>
 {
-    public override string Name => "load-duckdb";
+    public string Name => "load-duckdb";
 
-    protected override Task<StagingDatabase> AggregateAsync(IReadOnlyList<SnapshotFile> all, IPipelineContext context, CancellationToken cancellationToken)
-        => Task.FromResult(new StagingDatabase());
+    public async IAsyncEnumerable<StagingDatabase> RunAsync(
+        IAsyncEnumerable<SnapshotFile> input,
+        IPipelineContext context,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var snapshots = new List<SnapshotFile>();
+        await foreach (var snapshot in input.WithCancellation(cancellationToken))
+            snapshots.Add(snapshot);
+
+        if (snapshots.Count == 0)
+        {
+            logger.LogInformation("No snapshots to load; no staging database produced");
+            yield break;
+        }
+
+        yield return await LoadAsync(snapshots, cancellationToken);
+    }
+
+    private async Task<StagingDatabase> LoadAsync(
+        IReadOnlyList<SnapshotFile> snapshots,
+        CancellationToken cancellationToken)
+    {
+        var snapshotStorage = storageProvider.ForFolder(EtlPipelineFolders.Snapshots);
+        var stagingStorage = storageProvider.ForFolder(EtlPipelineFolders.Staging);
+
+        var sourceTimestamp = snapshots.Max(snapshot => snapshot.SourceTimestamp);
+        var outputKey = StagingFileNaming.DatabaseKey(sourceTimestamp);
+        var runId = snapshots[0].RunId;
+
+        if (await stagingStorage.ExistsAsync(outputKey, cancellationToken))
+        {
+            logger.LogInformation("Staging database {DatabaseKey} already exists; reusing it", outputKey);
+
+            return new StagingDatabase
+            {
+                RunId = runId,
+                Key = outputKey,
+                SourceTimestamp = sourceTimestamp,
+                Created = false
+            };
+        }
+
+        var workingDirectory = Directory.CreateTempSubdirectory("etl-staging-").FullName;
+
+        try
+        {
+            var sources = await DownloadAsync(snapshots, snapshotStorage, workingDirectory, cancellationToken);
+
+            var databasePath = Path.Combine(workingDirectory, "staging.duckdb");
+            var result = await databaseWriter.WriteAsync(sources, databasePath, cancellationToken);
+
+            await using (var published = await stagingStorage.OpenWriteAsync(
+                outputKey, StagingFileNaming.DatabaseContentType, cancellationToken: cancellationToken))
+            {
+                await using var database = new FileStream(databasePath, FileMode.Open, FileAccess.Read);
+                await database.CopyToAsync(published, cancellationToken);
+            }
+
+            logger.LogInformation(
+                "Wrote staging database {DatabaseKey} with {TableCount} table(s): {RowCount} rows",
+                outputKey, result.Tables.Count, result.Tables.Sum(table => table.RowCount));
+
+            return new StagingDatabase
+            {
+                RunId = runId,
+                Key = outputKey,
+                SourceTimestamp = sourceTimestamp,
+                Tables = result.Tables,
+                Created = true
+            };
+        }
+        finally
+        {
+            Directory.Delete(workingDirectory, recursive: true);
+        }
+    }
+
+    private static async Task<IReadOnlyList<StagingTableSource>> DownloadAsync(
+        IReadOnlyList<SnapshotFile> snapshots,
+        IBlobStorageService snapshotStorage,
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        var sources = new List<StagingTableSource>(snapshots.Count);
+
+        foreach (var snapshot in snapshots)
+        {
+            var tableName = snapshot.Definition.Name;
+            var parquetPath = Path.Combine(workingDirectory, $"{tableName}.parquet");
+
+            await using (var reader = await snapshotStorage.OpenReadAsync(snapshot.Key, cancellationToken))
+            {
+                await using var local = File.Create(parquetPath);
+                await reader.CopyToAsync(local, cancellationToken);
+            }
+
+            sources.Add(new StagingTableSource(tableName, parquetPath, snapshot.Key));
+        }
+
+        return sources;
+    }
 }

--- a/src/KeeperData.Core/EtlPipeline/Staging/IStagingDatabaseWriter.cs
+++ b/src/KeeperData.Core/EtlPipeline/Staging/IStagingDatabaseWriter.cs
@@ -1,0 +1,25 @@
+namespace KeeperData.Core.EtlPipeline.Staging;
+
+/// <summary>One dataset's snapshot on local disk, and the table it becomes.</summary>
+public sealed record StagingTableSource(string TableName, string ParquetPath, string SnapshotKey);
+
+/// <summary>A table in the staging database, and how many rows it holds.</summary>
+public sealed record StagingTable(string Name, string SnapshotKey, long RowCount);
+
+public sealed record StagingDatabaseWriteResult(IReadOnlyList<StagingTable> Tables);
+
+/// <summary>Builds the staging database from snapshot Parquet files.
+///
+/// Local paths in, local database out: the implementation owns the database engine and knows nothing
+/// about object storage, which keeps the engine out of Core and lets the load stage be tested without
+/// it.</summary>
+public interface IStagingDatabaseWriter
+{
+    /// <param name="databasePath">Where to create the database. Must not already exist.</param>
+    /// <exception cref="InvalidOperationException">A table's row count does not match its Parquet
+    /// source, so the database must not be published.</exception>
+    Task<StagingDatabaseWriteResult> WriteAsync(
+        IReadOnlyList<StagingTableSource> sources,
+        string databasePath,
+        CancellationToken cancellationToken = default);
+}

--- a/src/KeeperData.Core/EtlPipeline/Storage/StagingFileNaming.cs
+++ b/src/KeeperData.Core/EtlPipeline/Storage/StagingFileNaming.cs
@@ -1,0 +1,20 @@
+using KeeperData.Core.ETL.Impl;
+
+namespace KeeperData.Core.EtlPipeline.Storage;
+
+/// <summary>Naming convention for the files in the <see cref="EtlPipelineFolders.Staging"/> folder.
+/// Keys are relative to that folder, because <see cref="IEtlPipelineStorageProvider.ForFolder"/> hands
+/// out storage already rooted at it.</summary>
+public static class StagingFileNaming
+{
+    public const string DatabasePrefix = "keeper_data_bridge_";
+
+    public const string DatabaseExtension = ".duckdb";
+
+    public const string DatabaseContentType = "application/octet-stream";
+
+    /// <summary>The key of the staging database holding snapshots up to a given source timestamp,
+    /// e.g. <c>keeper_data_bridge_20251115121333.duckdb</c>.</summary>
+    public static string DatabaseKey(DateTimeOffset sourceTimestamp, string dateTimePattern = EtlConstants.DateTimePattern)
+        => $"{DatabasePrefix}{sourceTimestamp.UtcDateTime.ToString(dateTimePattern)}{DatabaseExtension}";
+}

--- a/src/KeeperData.Infrastructure/EtlPipeline/Setup/ServiceCollectionExtensions.cs
+++ b/src/KeeperData.Infrastructure/EtlPipeline/Setup/ServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
+using KeeperData.Core.EtlPipeline.Staging;
 using KeeperData.Core.EtlPipeline.Storage;
+using KeeperData.Infrastructure.EtlPipeline.Staging;
 using KeeperData.Infrastructure.EtlPipeline.Storage;
 using KeeperData.Infrastructure.Storage.Configuration;
 using Microsoft.Extensions.Configuration;
@@ -25,6 +27,8 @@ public static class ServiceCollectionExtensions
         {
             services.AddTransient<IEtlPipelineStorageProvider, S3EtlPipelineStorageProvider>();
         }
+
+        services.AddScoped<IStagingDatabaseWriter, DuckDbStagingDatabaseWriter>();
 
         return services;
     }

--- a/src/KeeperData.Infrastructure/EtlPipeline/Staging/DuckDbStagingDatabaseWriter.cs
+++ b/src/KeeperData.Infrastructure/EtlPipeline/Staging/DuckDbStagingDatabaseWriter.cs
@@ -1,0 +1,98 @@
+using DuckDB.NET.Data;
+using KeeperData.Core.EtlPipeline.Staging;
+using Microsoft.Extensions.Logging;
+
+namespace KeeperData.Infrastructure.EtlPipeline.Staging;
+
+/// <summary>Builds the staging database by having DuckDB read the snapshot Parquet files directly.
+///
+/// Reading Parquet here is not the delta merge the pipeline keeps out of DuckDB - the merge has
+/// already happened and produced these snapshots. This is the staging load.
+///
+/// Each table's row count is checked against its Parquet source before the writer returns, so a
+/// truncated read fails the load rather than publishing a database that is quietly short of rows.</summary>
+public sealed class DuckDbStagingDatabaseWriter(ILogger<DuckDbStagingDatabaseWriter> logger) : IStagingDatabaseWriter
+{
+    public async Task<StagingDatabaseWriteResult> WriteAsync(
+        IReadOnlyList<StagingTableSource> sources,
+        string databasePath,
+        CancellationToken cancellationToken = default)
+    {
+        if (File.Exists(databasePath))
+        {
+            throw new InvalidOperationException($"Staging database '{databasePath}' already exists");
+        }
+
+        await using var connection = new DuckDBConnection($"Data Source={databasePath}");
+        await connection.OpenAsync(cancellationToken);
+
+        var tables = new List<StagingTable>(sources.Count);
+
+        foreach (var source in sources)
+        {
+            tables.Add(await CreateTableAsync(connection, source, cancellationToken));
+        }
+
+        return new StagingDatabaseWriteResult(tables);
+    }
+
+    private async Task<StagingTable> CreateTableAsync(
+        DuckDBConnection connection,
+        StagingTableSource source,
+        CancellationToken cancellationToken)
+    {
+        var table = QuoteIdentifier(source.TableName);
+        var parquet = QuoteLiteral(source.ParquetPath);
+
+        await ExecuteAsync(
+            connection,
+            $"CREATE TABLE {table} AS SELECT * FROM read_parquet({parquet})",
+            cancellationToken);
+
+        var rowCount = await ScalarAsync(connection, $"SELECT count(*) FROM {table}", cancellationToken);
+        var parquetRowCount = await ScalarAsync(
+            connection, $"SELECT count(*) FROM read_parquet({parquet})", cancellationToken);
+
+        if (rowCount != parquetRowCount)
+        {
+            throw new InvalidOperationException(
+                $"Table '{source.TableName}' holds {rowCount} row(s) but '{source.SnapshotKey}' holds {parquetRowCount}");
+        }
+
+        logger.LogInformation(
+            "Loaded {RowCount} row(s) from {SnapshotKey} into staging table {TableName}",
+            rowCount, source.SnapshotKey, source.TableName);
+
+        return new StagingTable(source.TableName, source.SnapshotKey, rowCount);
+    }
+
+    private static async Task ExecuteAsync(DuckDBConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static async Task<long> ScalarAsync(DuckDBConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+
+        return Convert.ToInt64(await command.ExecuteScalarAsync(cancellationToken));
+    }
+
+    /// <summary>Table names come from the dataset definitions rather than from file content, but they
+    /// still reach SQL as text, so they are quoted rather than interpolated bare.</summary>
+    private static string QuoteIdentifier(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Table name is required", nameof(name));
+        }
+
+        return $"\"{name.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
+    }
+
+    private static string QuoteLiteral(string value)
+        => $"'{value.Replace("'", "''", StringComparison.Ordinal)}'";
+}

--- a/tests/KeeperData.Core.Tests.Unit/EtlPipeline/EtlPipelineFactoryTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/EtlPipeline/EtlPipelineFactoryTests.cs
@@ -18,7 +18,8 @@ public class EtlPipelineFactoryTests
         var factory = new EtlPipelineFactory(
             Mock.Of<IExternalCatalogueServiceFactory>(),
             AutoMocked.Instance<DecryptStage>(),
-            AutoMocked.Instance<SnapshotStage>());
+            AutoMocked.Instance<SnapshotStage>(),
+            AutoMocked.Instance<LoadDuckDbStage>());
 
         factory.Create().GetStageNames().Should().Equal(
             "discover",

--- a/tests/KeeperData.Core.Tests.Unit/EtlPipeline/LoadDuckDbStageTests.cs
+++ b/tests/KeeperData.Core.Tests.Unit/EtlPipeline/LoadDuckDbStageTests.cs
@@ -1,32 +1,160 @@
+using System.Text;
 using FluentAssertions;
+using KeeperData.Core.ETL.Impl;
 using KeeperData.Core.EtlPipeline.Payloads;
+using KeeperData.Core.EtlPipeline.Staging;
 using KeeperData.Core.EtlPipeline.Stages;
+using KeeperData.Core.EtlPipeline.Storage;
 using KeeperData.Core.Tests.Unit.EtlPipeline.Harness;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace KeeperData.Core.Tests.Unit.EtlPipeline;
 
 /// <summary>Load. Input: SnapshotFile (all of them). Output: one StagingDatabase.
-/// OWNER: add your DuckDB writer, then assert every snapshot becomes a table in the one database.</summary>
+/// Every snapshot becomes a table in the one database, named after the newest source timestamp
+/// loaded. The database engine itself is exercised in the infrastructure tests.</summary>
 public class LoadDuckDbStageTests
 {
-    private static Task<List<StagingDatabase>> RunAsync(params SnapshotFile[] inputs) =>
-        StageRunner.RunAsync(new LoadDuckDbStage(), inputs);
+    private readonly InMemoryEtlPipelineStorage _storage = new();
+    private readonly RecordingStagingDatabaseWriter _writer = new();
+
+    private InMemoryBlobStorage Snapshots => _storage.Folder(EtlPipelineFolders.Snapshots);
+    private InMemoryBlobStorage Staging => _storage.Folder(EtlPipelineFolders.Staging);
+
+    private Task<List<StagingDatabase>> RunAsync(params SnapshotFile[] inputs) =>
+        StageRunner.RunAsync(
+            new LoadDuckDbStage(_storage, _writer, NullLogger<LoadDuckDbStage>.Instance),
+            inputs);
+
+    private SnapshotFile Snapshot(string dataSet, string timestamp, string content = "parquet")
+    {
+        var key = $"{dataSet}/{dataSet}_{timestamp}.parquet";
+        Snapshots.Put(key, content);
+
+        return new SnapshotFile(new DataSetDefinition(dataSet, $"{dataSet}_{{0}}", ["CPH"], ChangeType.HeaderName, []))
+        {
+            Key = key,
+            SourceTimestamp = DateTimeOffset.ParseExact(
+                timestamp, EtlConstants.DateTimePattern, null, System.Globalization.DateTimeStyles.AssumeUniversal)
+        };
+    }
 
     [Fact]
     public async Task Collapses_all_snapshots_into_a_single_database()
     {
         var output = await RunAsync(
-            new SnapshotFile(StageRunner.Definition("SAM_CPH")),
-            new SnapshotFile(StageRunner.Definition("CTS_KEEPER")));
+            Snapshot("sam_cph_holdings", "20251115121333"),
+            Snapshot("cts_keeper", "20251114121333"));
 
         output.Should().ContainSingle();
+        Staging.Keys.Should().ContainSingle();
+        _writer.Sources.Select(source => source.TableName)
+            .Should().Equal("sam_cph_holdings", "cts_keeper");
     }
 
     [Fact]
-    public async Task Still_produces_a_single_database_for_an_empty_input()
+    public async Task Names_the_database_after_the_newest_source_timestamp_loaded()
+    {
+        var output = await RunAsync(
+            Snapshot("sam_cph_holdings", "20251115121333"),
+            Snapshot("cts_keeper", "20251114121333"));
+
+        output.Single().Key.Should().Be("keeper_data_bridge_20251115121333.duckdb");
+        output.Single().SourceTimestamp.Should().Be(
+            new DateTimeOffset(2025, 11, 15, 12, 13, 33, TimeSpan.Zero));
+        Staging.Keys.Should().Equal("keeper_data_bridge_20251115121333.duckdb");
+    }
+
+    [Fact]
+    public async Task Produces_no_database_for_an_empty_input()
     {
         var output = await RunAsync();
 
-        output.Should().ContainSingle();
+        output.Should().BeEmpty();
+        Staging.Keys.Should().BeEmpty();
+        _writer.Calls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Reuses_an_existing_database_for_the_same_snapshots()
+    {
+        Staging.Put("keeper_data_bridge_20251115121333.duckdb", "already here");
+
+        var output = await RunAsync(Snapshot("sam_cph_holdings", "20251115121333"));
+
+        output.Single().Created.Should().BeFalse();
+        _writer.Calls.Should().Be(0);
+        Staging.ContentOf("keeper_data_bridge_20251115121333.duckdb").Should().Be("already here");
+    }
+
+    [Fact]
+    public async Task Reports_the_tables_the_writer_created()
+    {
+        _writer.RowCount = 3;
+
+        var output = await RunAsync(Snapshot("sam_cph_holdings", "20251115121333"));
+
+        output.Single().Created.Should().BeTrue();
+        output.Single().Tables.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new StagingTable(
+                "sam_cph_holdings", "sam_cph_holdings/sam_cph_holdings_20251115121333.parquet", 3));
+    }
+
+    [Fact]
+    public async Task Hands_the_writer_the_snapshot_content_on_local_disk()
+    {
+        await RunAsync(Snapshot("sam_cph_holdings", "20251115121333", content: "the snapshot bytes"));
+
+        _writer.ContentWritten.Should().Equal("the snapshot bytes");
+    }
+
+    [Fact]
+    public async Task Publishes_nothing_when_the_writer_fails()
+    {
+        _writer.Fail = true;
+
+        var act = () => RunAsync(Snapshot("sam_cph_holdings", "20251115121333"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        Staging.Keys.Should().BeEmpty();
+    }
+
+    /// <summary>Stands in for the DuckDB writer: records what it was asked to load, and reads each
+    /// Parquet path so the test can prove the stage put the snapshot on disk for it.</summary>
+    private sealed class RecordingStagingDatabaseWriter : IStagingDatabaseWriter
+    {
+        public List<StagingTableSource> Sources { get; } = [];
+
+        public List<string> ContentWritten { get; } = [];
+
+        public int Calls { get; private set; }
+
+        public long RowCount { get; set; }
+
+        public bool Fail { get; set; }
+
+        public async Task<StagingDatabaseWriteResult> WriteAsync(
+            IReadOnlyList<StagingTableSource> sources,
+            string databasePath,
+            CancellationToken cancellationToken = default)
+        {
+            Calls++;
+            Sources.AddRange(sources);
+
+            foreach (var source in sources)
+            {
+                ContentWritten.Add(await System.IO.File.ReadAllTextAsync(source.ParquetPath, cancellationToken));
+            }
+
+            if (Fail)
+            {
+                throw new InvalidOperationException("writer failed");
+            }
+
+            await System.IO.File.WriteAllTextAsync(databasePath, "duckdb", Encoding.UTF8, cancellationToken);
+
+            return new StagingDatabaseWriteResult(
+                [.. sources.Select(source => new StagingTable(source.TableName, source.SnapshotKey, RowCount))]);
+        }
     }
 }

--- a/tests/KeeperData.Infrastructure.Tests.Unit/EtlPipeline/Staging/DuckDbStagingDatabaseWriterTests.cs
+++ b/tests/KeeperData.Infrastructure.Tests.Unit/EtlPipeline/Staging/DuckDbStagingDatabaseWriterTests.cs
@@ -1,0 +1,170 @@
+using DuckDB.NET.Data;
+using FluentAssertions;
+using KeeperData.Core.EtlPipeline.Staging;
+using KeeperData.Infrastructure.EtlPipeline.Staging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Parquet;
+using Parquet.Schema;
+
+namespace KeeperData.Infrastructure.Tests.Unit.EtlPipeline.Staging;
+
+/// <summary>Exercises the real DuckDB writer against real Parquet files on disk: the point of the
+/// stage is that the database it leaves behind can be opened and queried on its own.</summary>
+public class DuckDbStagingDatabaseWriterTests : IDisposable
+{
+    private readonly DuckDbStagingDatabaseWriter _sut = new(NullLogger<DuckDbStagingDatabaseWriter>.Instance);
+    private readonly string _tempDir;
+
+    public DuckDbStagingDatabaseWriterTests()
+    {
+        _tempDir = Directory.CreateTempSubdirectory("duckdb-staging-tests-").FullName;
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    private string DatabasePath => Path.Combine(_tempDir, "staging.duckdb");
+
+    [Fact]
+    public async Task Loads_a_snapshot_into_a_table_of_the_same_name()
+    {
+        var source = Parquet("sam_cph_holdings", "CPH|HOLDING_NAME", "01/001/0001|Updated Farm", "01/001/0003|New Farm");
+
+        var result = await _sut.WriteAsync([source], DatabasePath);
+
+        result.Tables.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new StagingTable("sam_cph_holdings", source.SnapshotKey, 2));
+
+        Query("SELECT CPH || '|' || HOLDING_NAME FROM sam_cph_holdings ORDER BY CPH")
+            .Should().Equal("01/001/0001|Updated Farm", "01/001/0003|New Farm");
+    }
+
+    [Fact]
+    public async Task Loads_every_snapshot_into_the_one_database()
+    {
+        await _sut.WriteAsync(
+            [
+                Parquet("sam_cph_holdings", "CPH", "01/001/0001"),
+                Parquet("cts_keeper", "CPH", "02/002/0002", "03/003/0003")
+            ],
+            DatabasePath);
+
+        Query("SELECT table_name FROM duckdb_tables() ORDER BY table_name")
+            .Should().Equal("cts_keeper", "sam_cph_holdings");
+        Query("SELECT count(*)::VARCHAR FROM cts_keeper").Should().Equal("2");
+    }
+
+    [Fact]
+    public async Task Row_count_matches_the_source_parquet_exactly()
+    {
+        var rows = Enumerable.Range(0, 500).Select(index => $"01/001/{index:0000}").ToArray();
+
+        var result = await _sut.WriteAsync([Parquet("sam_cph_holdings", "CPH", rows)], DatabasePath);
+
+        result.Tables.Single().RowCount.Should().Be(500);
+        Query("SELECT count(*)::VARCHAR FROM sam_cph_holdings").Should().Equal("500");
+    }
+
+    [Fact]
+    public async Task Loads_a_snapshot_holding_no_rows()
+    {
+        var result = await _sut.WriteAsync([Parquet("sam_cph_holdings", "CPH")], DatabasePath);
+
+        result.Tables.Single().RowCount.Should().Be(0);
+        Query("SELECT count(*)::VARCHAR FROM sam_cph_holdings").Should().Equal("0");
+    }
+
+    [Fact]
+    public async Task The_database_is_queryable_after_the_writer_has_closed_it()
+    {
+        await _sut.WriteAsync([Parquet("sam_cph_holdings", "CPH|HOLDING_NAME", "01/001/0002|Keep Farm")], DatabasePath);
+
+        File.Exists(DatabasePath).Should().BeTrue();
+        Query("SELECT HOLDING_NAME FROM sam_cph_holdings").Should().Equal("Keep Farm");
+    }
+
+    [Fact]
+    public async Task Refuses_to_write_over_an_existing_database()
+    {
+        await File.WriteAllTextAsync(DatabasePath, "already here");
+
+        var act = () => _sut.WriteAsync([Parquet("sam_cph_holdings", "CPH", "01/001/0001")], DatabasePath);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("*already exists*");
+    }
+
+    [Fact]
+    public async Task Fails_when_the_parquet_source_is_missing()
+    {
+        var missing = new StagingTableSource(
+            "sam_cph_holdings", Path.Combine(_tempDir, "absent.parquet"), "snapshots/absent.parquet");
+
+        var act = () => _sut.WriteAsync([missing], DatabasePath);
+
+        await act.Should().ThrowAsync<Exception>();
+    }
+
+    private StagingTableSource Parquet(string tableName, string header, params string[] rows)
+    {
+        var path = Path.Combine(_tempDir, $"{tableName}.parquet");
+        File.WriteAllBytes(path, ParquetBytes(header, rows));
+
+        return new StagingTableSource(tableName, path, $"snapshots/{tableName}/{tableName}_20251115121333.parquet");
+    }
+
+    private static byte[] ParquetBytes(string header, string[] rows)
+        => ParquetBytesAsync(header, rows).GetAwaiter().GetResult();
+
+    private static async Task<byte[]> ParquetBytesAsync(string header, string[] rows)
+    {
+        var columns = header.Split('|');
+        var values = columns.Select(_ => new List<string?>()).ToArray();
+
+        foreach (var cells in rows.Select(row => row.Split('|')))
+        {
+            for (var column = 0; column < columns.Length; column++)
+            {
+                values[column].Add(column < cells.Length ? cells[column] : null);
+            }
+        }
+
+        var fields = columns.Select(column => new DataField<string>(column)).ToArray();
+        var buffer = new MemoryStream();
+
+        await using (var writer = await ParquetWriter.CreateAsync(new ParquetSchema(fields), buffer))
+        {
+            using var rowGroup = writer.CreateRowGroup();
+
+            for (var column = 0; column < fields.Length; column++)
+            {
+                await rowGroup.WriteAsync(fields[column], (IReadOnlyCollection<string?>)values[column]);
+            }
+        }
+
+        return buffer.ToArray();
+    }
+
+    private List<string> Query(string sql)
+    {
+        using var connection = new DuckDBConnection($"Data Source={DatabasePath}");
+        connection.Open();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+
+        var results = new List<string>();
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            results.Add(reader.GetString(0));
+        }
+
+        return results;
+    }
+}


### PR DESCRIPTION
Introduced LoadDuckDbStage to load snapshots into a DuckDB staging database, with dependency-injected IStagingDatabaseWriter and DuckDbStagingDatabaseWriter implementation. Updated pipeline wiring and DI registration. Enhanced StagingDatabase payload with metadata. Added unit and integration tests for the stage and writer. Added StagingFileNaming utility for file naming. Implemented FileBasedStagingController to provide presigned download URLs for the latest staging database. Added StorageObjectInfoExtensions for selecting the latest file.